### PR TITLE
ci: backport action to build latest-4.9 iamges

### DIFF
--- a/.github/workflows/odf-push-build-release-image.yaml
+++ b/.github/workflows/odf-push-build-release-image.yaml
@@ -1,0 +1,69 @@
+name: ODF releases - Build and Push Image to Quay
+on:
+  push:
+    branches:
+      - release-*
+      # do not match branches like release-4.9-temp
+      - !release-*-*
+
+#
+# NOTE: this MUST be backported to each release-X.Y branch on which the workflow should run!
+#
+
+defaults:
+  run:
+    # reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+
+jobs:
+  build-and-push-to-quay:
+    name: build and push release images to quay
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: setup golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: unshallow repository
+      run: git fetch --prune --unshallow --tags
+
+    - name: build x86_64 image
+      id: build-image
+      run: |
+        branch_name="${GITHUB_REF##*/}" # e.g., refs/heads/release-4.9 -> release-4.9
+        odf_release="${branch_name#release-}"  # e.g., release-4.9 -> 4.9
+        commits="$(git rev-list --count HEAD)" # monotonically increasing number of commits
+        hash="$(git rev-parse --short HEAD)"
+        # config build with env vars and do the build
+        export GOPATH=$(go env GOPATH)
+        export IMAGES='ceph'
+        export BUILD_REGISTRY='rook-build'
+        export VERSION="${odf_release}-${commits}.${hash}" # e.g., 4.9-7094.5e3d5026a
+        make build
+        # find and re-tag the built image
+        built_image="$(docker images --format "{{.Repository}}" | grep rook-build)"
+        out_image="rook-ceph"
+        latest_tag="latest-${odf_release}"
+        docker tag "$built_image" "${out_image}:${VERSION}" # e.g., rook-ceph:4.9-7094.5e3d5026a
+        docker tag "$built_image" "${out_image}:${latest_tag}" # e.g., rook-ceph:latest-4.9
+        # set step outputs that can be referenced by later steps
+        echo "::set-output name=image::${out_image}" # e.g., rook-ceph
+        echo "::set-output name=tags::${VERSION} ${latest_tag}" # e.g., 4.9-7094.5e3d5026a latest-4.9
+
+    - name: push To quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: quay.io/${{ secrets.QUAY_OCS_DEV_REGISTRY }}
+        username: ${{ secrets.QUAY_OCS_DEV_ROBOT_USER }}
+        password: ${{ secrets.QUAY_OCS_DEV_ROBOT_PASSWORD }}
+
+    - name: print pushed image URLs
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
Backport the ODF-only GitHub action to build and release latest-4.9
images to quay.io/ocs-dev

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

This is not related to a BZ and is not a code change at all. This merely makes it so GitHub actions will resume building `latest-4.9` images to https://quay.io/repository/ocs-dev/rook-ceph?tag=latest&tab=tags

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
