### PR TITLE
Bug 1983756: ceph: do not build all the args to remote exec cmd

### DIFF
--- a/pkg/daemon/ceph/client/command_test.go
+++ b/pkg/daemon/ceph/client/command_test.go
@@ -115,6 +115,7 @@ func TestNewRBDCommand(t *testing.T) {
 		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 			switch {
 			case command == "rbd" && args[0] == "create":
+				assert.Len(t, args, 8)
 				return "success", nil
 			}
 			return "", errors.Errorf("unexpected ceph command %q", args)
@@ -136,6 +137,7 @@ func TestNewRBDCommand(t *testing.T) {
 		assert.True(t, cmd.RemoteExecution)
 		_, err := cmd.Run()
 		assert.Error(t, err)
+		assert.Len(t, cmd.args, 4)
 		// This is not the best but it shows we go through the right codepath
 		assert.EqualError(t, err, "no pods found with selector \"rook-ceph-mgr\"")
 	})


### PR DESCRIPTION
When proxying commands to the cmd-proxy container we don't need to build
the command line with the same flags as the operator. The cmd-proxy
container does not use any ceph config file and just relies on the
CEPH_ARGS environment variable in the container. So passing the same
args as the operator causes to fail since we don't have a ceph config
file in `/var/lib/rook/openshift-storage/openshift-storage.config` thus
the remote exec fails with:

```
global_init: unable to open config file from search list ...
```

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 17999bcb3d89b12740c8342c55fbd628b7b3c841)
(cherry picked from commit d7b93679a8569632eb899d1e9f0c8dad00778d4b)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
