### PR TITLE
Bug 2008471: ceph: do not fail on keys deletion

### DIFF
--- a/pkg/daemon/ceph/osd/kms/vault.go
+++ b/pkg/daemon/ceph/osd/kms/vault.go
@@ -183,7 +183,7 @@ func buildKeyContext(config map[string]string) map[string]string {
 	keyContext := map[string]string{secrets.KeyVaultNamespace: config[api.EnvVaultNamespace]}
 	vaultNamespace, ok := config[api.EnvVaultNamespace]
 	if !ok || vaultNamespace == "" {
-		keyContext = nil
+		keyContext = map[string]string{}
 	}
 
 	return keyContext

--- a/pkg/daemon/ceph/osd/kms/vault_test.go
+++ b/pkg/daemon/ceph/osd/kms/vault_test.go
@@ -157,3 +157,27 @@ func Test_configTLS(t *testing.T) {
 	assert.NotEqual(t, "vault-client-cert", config["VAULT_CLIENT_CERT"])
 	assert.NotEqual(t, "vault-client-key", config["VAULT_CLIENT_KEY"])
 }
+
+func Test_buildKeyContext(t *testing.T) {
+	t.Run("no vault namespace, return empty map and assignment is possible", func(t *testing.T) {
+		config := map[string]string{
+			"KMS_PROVIDER": "vault",
+			"VAULT_ADDR":   "1.1.1.1",
+		}
+		context := buildKeyContext(config)
+		assert.Len(t, context, 0)
+		context["foo"] = "bar"
+	})
+
+	t.Run("vault namespace, return 1 single element in the map and assignment is possible", func(t *testing.T) {
+		config := map[string]string{
+			"KMS_PROVIDER":    "vault",
+			"VAULT_ADDR":      "1.1.1.1",
+			"VAULT_NAMESPACE": "vault-namespace",
+		}
+		context := buildKeyContext(config)
+		assert.Len(t, context, 1)
+		context["foo"] = "bar"
+		assert.Len(t, context, 2)
+	})
+}


### PR DESCRIPTION
Prior, we were returning a nil map and thus the assignment for forced
deletion was not working since we were trying to assign on a nil map.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 2e73baf4f590cad7626fb9763b46dfe8a541c6b2)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
