### PR TITLE
Bug 1944513: [release 4.9] fix ceph mon quorum lost alert query

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
@@ -90,7 +90,7 @@ spec:
         severity_level: critical
         storage_type: ceph
       expr: |
-        count(kube_pod_status_phase{pod=~"rook-ceph-mon-.*", phase=~"Running|running"}) by (namespace) < 2
+        count(kube_pod_status_phase{pod=~"rook-ceph-mon-.*", phase=~"Running|running"} == 1) by (namespace) < 2
       for: 5m
       labels:
         severity: critical


### PR DESCRIPTION
Only the 'Running' mons with result value of '1' should be counted.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>
(cherry picked from commit af44e5c58470f3bf1d5e950dc19e07c70de693da)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
