### PR TITLE
rgw: add startup probe to RGW pod

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -170,6 +170,7 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) v1.Container {
 		),
 		Env:             controller.DaemonEnvVars(c.clusterSpec.CephVersion.Image),
 		Resources:       c.store.Spec.Gateway.Resources,
+		StartupProbe:    c.generateStartupProbe(),
 		LivenessProbe:   c.generateLiveProbe(),
 		SecurityContext: controller.PodSecurityContext(),
 	}
@@ -210,6 +211,21 @@ func (c *clusterConfig) generateLiveProbe() *v1.Probe {
 			},
 		},
 		InitialDelaySeconds: 10,
+	}
+}
+
+func (c *clusterConfig) generateStartupProbe() *v1.Probe {
+	return &v1.Probe{
+		Handler: v1.Handler{
+			HTTPGet: &v1.HTTPGetAction{
+				Path:   livenessProbePath,
+				Port:   c.generateLiveProbePort(), // same as liveness but allows for longer RGW startup times
+				Scheme: c.generateLiveProbeScheme(),
+			},
+		},
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       10,
+		FailureThreshold:    18,
 	}
 }
 


### PR DESCRIPTION
Add a startup probe to the RGW pod. Allow 180 seconds for the RGW to
start responding to its /swift/healthcheck endpoint. Usually the RGW
starts up in less than 30 seconds, but it has observed to start between
60-90 seconds into container start in some instances.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
