### PR TITLE
Bug 2049718: subvolumegroup: handle external mode

### DIFF
--- a/pkg/daemon/ceph/client/subvolumegroup.go
+++ b/pkg/daemon/ceph/client/subvolumegroup.go
@@ -24,33 +24,34 @@ import (
 // CreateCephFSSubVolumeGroup create a CephFS subvolume group.
 // volName is the name of the Ceph FS volume, the same as the CephFilesystem CR name.
 func CreateCephFSSubVolumeGroup(context *clusterd.Context, clusterInfo *ClusterInfo, volName, groupName string) error {
-	logger.Infof("creating cephfs sub volume group %q", volName)
+	logger.Infof("creating cephfs subvolume group %q", volName)
 	//  [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>]
 	args := []string{"fs", "subvolumegroup", "create", volName, groupName}
 	cmd := NewCephCommand(context, clusterInfo, args)
 	cmd.JsonOutput = false
 	output, err := cmd.Run()
 	if err != nil {
-		return errors.Wrapf(err, "failed to create sub volume group %q. %s", volName, output)
+		return errors.Wrapf(err, "failed to create subvolume group %q. %s", volName, output)
 	}
 
-	logger.Infof("successfully created cephfs sub volume group %q", volName)
+	logger.Infof("successfully created cephfs subvolume group %q", volName)
 	return nil
 }
 
 // DeleteCephFSSubVolumeGroup delete a CephFS subvolume group.
 func DeleteCephFSSubVolumeGroup(context *clusterd.Context, clusterInfo *ClusterInfo, volName, groupName string) error {
-	logger.Infof("deleting cephfs sub volume group %q", volName)
+	logger.Infof("deleting cephfs subvolume group %q", volName)
 	//  --force?
 	args := []string{"fs", "subvolumegroup", "rm", volName, groupName}
 	cmd := NewCephCommand(context, clusterInfo, args)
 	cmd.JsonOutput = false
-	_, err := cmd.Run()
+	output, err := cmd.Run()
 	if err != nil {
+		logger.Debugf("failed to delete subvolume group %q. %s. %v", volName, output, err)
 		// Intentionally don't wrap the error so the caller can inspect the return code
 		return err
 	}
 
-	logger.Infof("successfully deleted cephfs sub volume group %q", volName)
+	logger.Infof("successfully deleted cephfs subvolume group %q", volName)
 	return nil
 }


### PR DESCRIPTION
If the cluster is external, users might still want to take advantage of
the ceph-csi configmap configuration for ceph filesystem subvolume
group. This configuration is handled by the controller whenever a
cephFilesystemSubVolumeGroup CR is created or deleted.
If the present cluster CephCluster is external, the controller
(cephFilesystemSubVolumeGroup) won't handle creation nor deletion of sub volume groups.
It just assumes that the given name is correct and the controller goes ahead with the
ceph-csi configuration.

Closes: #9551
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 49f75c8ec3252dc9af4ed07461bd0006e8d151c6)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
