### PR TITLE
Bug 2052996: object: do not check for upgrade on external mode

### DIFF
--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/exec"
 	appsv1 "k8s.io/api/apps/v1"
@@ -290,35 +291,45 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, cephObjectStore, nil
 	}
 
-	// Detect desired CephCluster version
-	runningCephVersion, desiredCephVersion, err := currentAndDesiredCephVersion(
-		r.opManagerContext,
-		r.opConfig.Image,
-		cephObjectStore.Namespace,
-		controllerName,
-		k8sutil.NewOwnerInfo(cephObjectStore, r.scheme),
-		r.context,
-		r.clusterSpec,
-		r.clusterInfo,
-	)
-	if err != nil {
-		if strings.Contains(err.Error(), opcontroller.UninitializedCephConfigError) {
-			logger.Info(opcontroller.OperatorNotInitializedMessage)
-			return opcontroller.WaitForRequeueIfOperatorNotInitialized, cephObjectStore, nil
+	var desiredCephVersion cephver.CephVersion
+	if cephObjectStore.Spec.IsExternal() {
+		// Check the ceph version of the running monitors
+		desiredCephVersion, err = cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo, config.MonType)
+		if err != nil {
+			return reconcile.Result{}, nil, errors.Wrapf(err, "failed to retrieve current ceph %q version", config.MonType)
 		}
-		return reconcile.Result{}, cephObjectStore, errors.Wrap(err, "failed to detect running and desired ceph version")
+	} else {
+		// Detect desired CephCluster version
+		runningCephVersion, desiredCephVersion, err := currentAndDesiredCephVersion(
+			r.opManagerContext,
+			r.opConfig.Image,
+			cephObjectStore.Namespace,
+			controllerName,
+			k8sutil.NewOwnerInfo(cephObjectStore, r.scheme),
+			r.context,
+			r.clusterSpec,
+			r.clusterInfo,
+		)
+		if err != nil {
+			if strings.Contains(err.Error(), opcontroller.UninitializedCephConfigError) {
+				logger.Info(opcontroller.OperatorNotInitializedMessage)
+				return opcontroller.WaitForRequeueIfOperatorNotInitialized, cephObjectStore, nil
+			}
+			return reconcile.Result{}, cephObjectStore, errors.Wrap(err, "failed to detect running and desired ceph version")
+		}
+
+		// If the version of the Ceph monitor differs from the CephCluster CR image version we assume
+		// the cluster is being upgraded. So the controller will just wait for the upgrade to finish and
+		// then versions should match. Obviously using the cmd reporter job adds up to the deployment time
+		if !reflect.DeepEqual(*runningCephVersion, *desiredCephVersion) {
+			// Upgrade is in progress, let's wait for the mons to be done
+			return opcontroller.WaitForRequeueIfCephClusterIsUpgrading,
+				cephObjectStore,
+				opcontroller.ErrorCephUpgradingRequeue(desiredCephVersion, runningCephVersion)
+		}
 	}
 
-	// If the version of the Ceph monitor differs from the CephCluster CR image version we assume
-	// the cluster is being upgraded. So the controller will just wait for the upgrade to finish and
-	// then versions should match. Obviously using the cmd reporter job adds up to the deployment time
-	if !reflect.DeepEqual(runningCephVersion, desiredCephVersion) {
-		// Upgrade is in progress, let's wait for the mons to be done
-		return opcontroller.WaitForRequeueIfCephClusterIsUpgrading,
-			cephObjectStore,
-			opcontroller.ErrorCephUpgradingRequeue(desiredCephVersion, runningCephVersion)
-	}
-	r.clusterInfo.CephVersion = *desiredCephVersion
+	r.clusterInfo.CephVersion = desiredCephVersion
 
 	// validate the store settings
 	if err := r.validateStore(cephObjectStore); err != nil {


### PR DESCRIPTION
**Description of your changes:**

The object child controller should not compare versions if the object
store is external. The current version comparison is using the
cmdreporter to check the ceph version of the image in the CephCluster spec.
In external mode, this image is not set so the cmdreporter fails.
Also, this check is only valid for converged mode, so external mode
should be skipped.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 856b14e60a1a49f61f9f1bf0d63f4f70c13b326a)
(cherry picked from commit dfe060100590d32ab5dd347047a0b09ff7e68d0e)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
