### PR TITLE
Bug 2052996: rgw: fix variable assignment

### DIFF
--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -34,7 +34,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/exec"
 	appsv1 "k8s.io/api/apps/v1"
@@ -291,13 +290,13 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, cephObjectStore, nil
 	}
 
-	var desiredCephVersion cephver.CephVersion
 	if cephObjectStore.Spec.IsExternal() {
 		// Check the ceph version of the running monitors
-		desiredCephVersion, err = cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo, config.MonType)
+		desiredCephVersion, err := cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo, config.MonType)
 		if err != nil {
 			return reconcile.Result{}, nil, errors.Wrapf(err, "failed to retrieve current ceph %q version", config.MonType)
 		}
+		r.clusterInfo.CephVersion = desiredCephVersion
 	} else {
 		// Detect desired CephCluster version
 		runningCephVersion, desiredCephVersion, err := currentAndDesiredCephVersion(
@@ -327,9 +326,8 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 				cephObjectStore,
 				opcontroller.ErrorCephUpgradingRequeue(desiredCephVersion, runningCephVersion)
 		}
+		r.clusterInfo.CephVersion = *desiredCephVersion
 	}
-
-	r.clusterInfo.CephVersion = desiredCephVersion
 
 	// validate the store settings
 	if err := r.validateStore(cephObjectStore); err != nil {

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -519,6 +519,7 @@ func TestCephObjectStoreController(t *testing.T) {
 		assert.NotEmpty(t, objectStore.Status.Info["endpoint"], objectStore)
 		assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc:80", objectStore.Status.Info["endpoint"], objectStore)
 		assert.True(t, calledCommitConfigChanges)
+		assert.Equal(t, 16, r.clusterInfo.CephVersion.Major)
 	})
 }
 


### PR DESCRIPTION
We need to explicitly assign the ceph version within each scope since
one function returns a pointer and one is not.
Previously, the `desiredCephVersion` was recreated in the scope of the
`else` and thus a new variable `desiredCephVersion` was initialized (see
the `:=`).
Now, each scope creates and assign to clusterInfo a `desiredCephVersion`
value.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 7f32461b8fee0b41f362c10f6a30367c3370fbeb)
(cherry picked from commit d233fd2293b5a6f273b543601df219f38e02142e)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
