### PR TITLE
Bug 2028483: monitoring: making alert firing timeout and the doc timeout same

### DIFF
--- a/deploy/examples/monitoring/prometheus-ceph-v14-rules.yaml
+++ b/deploy/examples/monitoring/prometheus-ceph-v14-rules.yaml
@@ -247,7 +247,7 @@ spec:
         severity: critical
     - alert: CephClusterWarningState
       annotations:
-        description: Storage cluster is in warning state for more than 10m.
+        description: Storage cluster is in warning state for more than 15m.
         message: Storage cluster is in degraded state
         severity_level: warning
         storage_type: ceph


### PR DESCRIPTION
Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>
(cherry picked from commit 054d009af6a345d65c882a6b352dba3054abf91e)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
