### PR TITLE
Bug 2054898: osd: Return error if fail to list osds in prepare job

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -142,7 +142,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			// List THE existing OSD configured with ceph-volume lvm mode
 			lvmOsds, err = GetCephVolumeLVMOSDs(context, a.clusterInfo, a.clusterInfo.FSID, lvPath, skipLVRelease, lvBackedPV)
 			if err != nil {
-				logger.Infof("failed to get device already provisioned by ceph-volume lvm. %v", err)
+				return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume lvm")
 			}
 			osds = append(osds, lvmOsds...)
 			if len(osds) > 0 {
@@ -166,7 +166,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 
 				rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV, false)
 				if err != nil {
-					logger.Infof("failed to get device already provisioned by ceph-volume raw. %v", err)
+					return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume raw")
 				}
 				osds = append(osds, rawOsds...)
 			}
@@ -176,14 +176,14 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			// List existing OSD(s) configured with ceph-volume lvm mode
 			lvmOsds, err = GetCephVolumeLVMOSDs(context, a.clusterInfo, a.clusterInfo.FSID, lvPath, false, false)
 			if err != nil {
-				logger.Infof("failed to get devices already provisioned by ceph-volume. %v", err)
+				return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume")
 			}
 			osds = append(osds, lvmOsds...)
 
 			// List existing OSD(s) configured with ceph-volume raw mode
 			rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, "", "", false, false)
 			if err != nil {
-				logger.Infof("failed to get device already provisioned by ceph-volume raw. %v", err)
+				return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume raw")
 			}
 			osds = appendOSDInfo(osds, rawOsds)
 		}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -448,7 +448,7 @@ func TestConfigureCVDevices(t *testing.T) {
 			if command == "sgdisk" {
 				return "Disk identifier (GUID): 18484D7E-5287-4CE9-AC73-D02FB69055CE", nil
 			}
-			if args[1] == "ceph-volume" && args[4] == "lvm" && args[5] == "list" && args[6] == mapperDev {
+			if args[1] == "ceph-volume" && args[4] == "lvm" && args[5] == "list" {
 				return `{}`, nil
 			}
 			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" && args[6] == mountedDev {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSD prepare job was succeeding even if the OSDs failed to be listed by ceph-volume. These errors should be returned and fail the job, resulting in a retry to retrieve the OSDs. Otherwise, the failure is masked and the admin needs to dig through logs to find why the OSDs were not configured on that node.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=2054898

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
