### PR TITLE
Bug 1947482: osd: Purge job will remove all pvcs for the osd

### DIFF
--- a/deploy/charts/library/templates/_cluster-role.tpl
+++ b/deploy/charts/library/templates/_cluster-role.tpl
@@ -109,5 +109,5 @@ rules:
     verbs: ["get", "list", "delete" ]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "update", "delete"]
+    verbs: ["get", "update", "delete", "list"]
 {{- end }}

--- a/deploy/examples/common-second-cluster.yaml
+++ b/deploy/examples/common-second-cluster.yaml
@@ -145,7 +145,7 @@ rules:
     verbs: ["get", "list", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "update", "delete"]
+    verbs: ["get", "update", "delete", "list"]
 ---
 # Allow the osd purge job to run in this namespace
 kind: RoleBinding

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -997,7 +997,7 @@ rules:
     verbs: ["get", "list", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "update", "delete"]
+    verbs: ["get", "update", "delete", "list"]
 ---
 # Allow the operator to manage resources in its own namespace
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/daemon/ceph/osd/remove_test.go
+++ b/pkg/daemon/ceph/osd/remove_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2022 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
+	testexec "github.com/rook/rook/pkg/operator/test"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestRemovePVCs(t *testing.T) {
+	pvcSuffix := 0
+	pvcReactor := func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		// PVCs are created with generateName used, and we need to capture the create calls and
+		// generate a name for them in order for PVCs to all have unique names.
+		createAction, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			t.Fatal("not a create action")
+			return false, nil, nil
+		}
+		obj := createAction.GetObject()
+		pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+		if !ok {
+			t.Fatal("not a PVC")
+			return false, nil, nil
+		}
+		if pvc.Name == "" {
+			pvc.Name = fmt.Sprintf("%s-%d", pvc.GenerateName, pvcSuffix)
+			logger.Info("generated name for PVC:", pvc.Name)
+			pvcSuffix++
+		}
+		// setting pvc.Name above modifies the action in-place before future reactors occur
+		// we want the default reactor to create the resource, so return false as if we did nothing
+		return false, nil, nil
+	}
+	ns := "testns"
+	ctx := context.TODO()
+	clusterInfo := client.AdminTestClusterInfo(ns)
+
+	t.Run("remove osd with data pvc", func(t *testing.T) {
+		clientset := testexec.New(t, 1)
+		clientset.PrependReactor("create", "persistentvolumeclaims", pvcReactor)
+		context := &clusterd.Context{
+			Clientset: clientset,
+		}
+
+		// Create 3 PVCs for two OSDs in the device set
+		deviceSet := cephv1.StorageClassDeviceSet{
+			Name:                 "mydata",
+			Count:                2,
+			Portable:             true,
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{testVolumeClaim("data")},
+			SchedulerName:        "custom-scheduler",
+		}
+		err := createTestPVCs(context, clusterInfo, deviceSet)
+		assert.NoError(t, err)
+
+		// Verify the PVCs all exist
+		pvcs, err := clientset.CoreV1().PersistentVolumeClaims(clusterInfo.Namespace).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(pvcs.Items))
+
+		// Verify the PVCs all exist for the given OSD
+		selector := fmt.Sprintf("%s=%s", oposd.CephSetIndexLabelKey, "0")
+		pvcs, err = clientset.CoreV1().PersistentVolumeClaims(clusterInfo.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(pvcs.Items))
+		assert.Equal(t, "mydata-data-0-0", pvcs.Items[0].Name)
+
+		// Remove the PVCs for one of the OSDs
+		removePVCs(context, clusterInfo, "mydata-data-0-0", false)
+
+		// Verify the PVCs all exist
+		pvcs, err = clientset.CoreV1().PersistentVolumeClaims(clusterInfo.Namespace).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(pvcs.Items))
+		assert.Equal(t, "mydata-data-1-1", pvcs.Items[0].Name)
+	})
+
+	t.Run("remove osd with metadata and wal pvcs", func(t *testing.T) {
+		clientset := testexec.New(t, 1)
+		clientset.PrependReactor("create", "persistentvolumeclaims", pvcReactor)
+		context := &clusterd.Context{
+			Clientset: clientset,
+		}
+
+		// Create 3 PVCs for two OSDs in the device set
+		deviceSet := cephv1.StorageClassDeviceSet{
+			Name:                 "mydata",
+			Count:                2,
+			Portable:             true,
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{testVolumeClaim("data"), testVolumeClaim("metadata"), testVolumeClaim("wal")},
+			SchedulerName:        "custom-scheduler",
+		}
+		err := createTestPVCs(context, clusterInfo, deviceSet)
+		assert.NoError(t, err)
+
+		// Verify the PVCs all exist
+		pvcs, err := clientset.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 6, len(pvcs.Items))
+
+		// Verify the PVCs all exist for the given OSD
+		selector := fmt.Sprintf("%s=%s", oposd.CephSetIndexLabelKey, "0")
+		pvcs, err = clientset.CoreV1().PersistentVolumeClaims(clusterInfo.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(pvcs.Items))
+
+		// Remove the PVCs for one of the OSDs
+		removePVCs(context, clusterInfo, "mydata-data-0-2", false)
+
+		// Verify the PVCs all deleted for the given OSD
+		pvcs, err = clientset.CoreV1().PersistentVolumeClaims(clusterInfo.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(pvcs.Items))
+		// Verify the PVCs for the other OSD still exist
+		pvcs, err = clientset.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(pvcs.Items))
+	})
+}
+
+func createTestPVCs(clusterdContext *clusterd.Context, clusterInfo *client.ClusterInfo, deviceSet cephv1.StorageClassDeviceSet) error {
+	spec := cephv1.ClusterSpec{
+		Storage: cephv1.StorageScopeSpec{StorageClassDeviceSets: []cephv1.StorageClassDeviceSet{deviceSet}},
+	}
+	cluster := oposd.New(clusterdContext, clusterInfo, spec, "")
+	return cluster.PrepareStorageClassDeviceSets()
+}
+
+func testVolumeClaim(name string) corev1.PersistentVolumeClaim {
+	storageClass := "mysource"
+	claim := corev1.PersistentVolumeClaim{Spec: corev1.PersistentVolumeClaimSpec{
+		StorageClassName: &storageClass,
+	}}
+	claim.Name = name
+	return claim
+}

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -66,6 +66,17 @@ type deviceSet struct {
 	Encrypted bool
 }
 
+// PrepareStorageClassDeviceSets is only exposed for testing purposes
+func (c *Cluster) PrepareStorageClassDeviceSets() error {
+	errors := newProvisionErrors()
+	c.prepareStorageClassDeviceSets(errors)
+	if len(errors.errors) > 0 {
+		// return the first error
+		return errors.errors[0]
+	}
+	return nil
+}
+
 func (c *Cluster) prepareStorageClassDeviceSets(errs *provisionErrors) {
 	c.deviceSets = []deviceSet{}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The purge job is intended to clean up all the resources related to an OSD that is to be removed. An OSD with a metadata, wal, and data PVC was only cleaning up the data PVC. Now the metadata and wal PVCs will also be cleaned up.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=1947482

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
