### PR TITLE
BUG 2062559: core: fix empty string bug

### DIFF
--- a/pkg/operator/ceph/csi/util.go
+++ b/pkg/operator/ceph/csi/util.go
@@ -99,10 +99,9 @@ func applyResourcesToContainers(opConfig map[string]string, key string, podspec 
 func getComputeResource(opConfig map[string]string, key string) []k8sutil.ContainerResource {
 	// Add Resource list if any
 	resource := []k8sutil.ContainerResource{}
-	resourceRaw := ""
 	var err error
 
-	if k8sutil.GetValue(opConfig, key, "") != "" {
+	if resourceRaw := k8sutil.GetValue(opConfig, key, ""); resourceRaw != "" {
 		resource, err = k8sutil.YamlToContainerResource(resourceRaw)
 		if err != nil {
 			logger.Warningf("failed to parse %q. %v", resourceRaw, err)


### PR DESCRIPTION
This function was always using an empty string, instead of the extracted resources

Signed-off-by: Tom Hellier <me@tomhellier.com>
(cherry picked from commit 59b4c57406f7a3d80109b917cad36afcc87c4519)

