### PR TITLE
Bug 2061657: osd: clarify vault auth error message

### DIFF
--- a/pkg/daemon/ceph/osd/kms/vault_api.go
+++ b/pkg/daemon/ceph/osd/kms/vault_api.go
@@ -93,6 +93,9 @@ func newVaultClient(clusterdContext *clusterd.Context, namespace string, secretC
 	// Both return a token
 	token, _, err := utils.Authenticate(client, c)
 	if err != nil {
+		if authType := GetParam(secretConfig, vault.AuthMethod); authType == vault.AuthMethodKubernetes {
+			return nil, errors.Wrap(err, "failed to get vault authentication token for kubernetes authentication (missing Service Account?)")
+		}
 		return nil, errors.Wrap(err, "failed to get vault authentication token")
 	}
 


### PR DESCRIPTION
When kube authentication is used, let's clarify the error message and
hopefully lead to a better understanding on where to look for.
It could be misleading to print "token auth" when using kube auth,
although internally a token is used (the JWT from the Service
Account).

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 74081d90d307b961fdc2980d440ec507f73489a5)
(cherry picked from commit 3cf062243d388002e7dbea62b285c298bcc985da)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
