### PR TITLE
Bug 1996833: core: fix incorrect join command

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -860,7 +860,10 @@ class RadosJSON:
         self.out_map['RBD_METADATA_EC_POOL_NAME'] = self.validate_rgw_metadata_ec_pool_name()
         self.out_map['RGW_POOL_PREFIX'] = self._arg_parser.rgw_pool_prefix
         if self._arg_parser.rgw_endpoint:
-            self.out_map['ACCESS_KEY'], self.out_map['SECRET_KEY'] = self.create_rgw_admin_ops_user()
+            if self._arg_parser.dry_run:
+                self.create_rgw_admin_ops_user()
+            else:
+                self.out_map['ACCESS_KEY'], self.out_map['SECRET_KEY'] = self.create_rgw_admin_ops_user()
             if self._arg_parser.rgw_tls_cert_path:
                 self.out_map['RGW_TLS_CERT'] = self.validate_rgw_endpoint_tls_cert()
 

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -768,7 +768,7 @@ class RadosJSON:
         cmd = ['radosgw-admin', 'user', 'create', '--uid', self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME, '--display-name',
                'Rook RGW Admin Ops user', '--caps', 'buckets=*;users=*;usage=read;metadata=read;zone=read']
         if self._arg_parser.dry_run:
-            return self.dry_run("ceph " + "".joing(cmd))
+            return self.dry_run("ceph " + " ".join(cmd))
         try:
             output = subprocess.check_output(cmd,
                                              stderr=subprocess.PIPE)

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -879,6 +879,8 @@ class RadosJSON:
 
     def gen_json_out(self):
         self._gen_output_map()
+        if self._arg_parser.dry_run:
+            return ""
         json_out = [
             {
                 "name": "rook-ceph-mon-endpoints",
@@ -1082,9 +1084,6 @@ class RadosJSON:
                     "cert": self.out_map['RGW_TLS_CERT'],
                 }
             })
-
-        if self._arg_parser.dry_run:
-            return ""
 
         return json.dumps(json_out)+LINESEP
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

core: fix incorrect join command
Fixing typo in join command
joing -> join

core: assign ACCESS_KEY and SECRET_KEY values only in case of actual run
When using dry-run option with external script, function create_rgw_admin_ops_user
is not returning expected values which leads to TypeError. This fix is to append
values to out_map dictionary only in case of actual run.

core: avoid creating json_out incase of dry-run
When using dry-run option with external script, out_map dictionary
doesn't contain keys ( ACCESS_KEY and SECRET_KEY ) which leads to KeyError.
This fix to avoid creating json_out incase of dry-run since we will not use
json_out for dry-run.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
