### PR TITLE
Bug 2069795: core: reload go routine after CR is edited

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -375,8 +375,12 @@ func (c *ClusterController) requestClusterDelete(cluster *cephv1.CephCluster) (r
 		// since the op manager context is cancelled.
 		// close the goroutines watching the health of the cluster (mons, osds, ceph status)
 		for _, daemon := range monitorDaemonList {
-			if monitoring, ok := cluster.monitoringRoutines[daemon]; ok && monitoring.internalCtx.Err() == nil { // if the context hasn't been cancelled
-				cluster.monitoringRoutines[daemon].internalCancel()
+			if monitoring, ok := cluster.monitoringRoutines[daemon]; ok && monitoring.InternalCtx.Err() == nil { // if the context hasn't been cancelled
+				// Stop the monitoring routine
+				cluster.monitoringRoutines[daemon].InternalCancel()
+
+				// Remove the monitoring routine from the map
+				delete(cluster.monitoringRoutines, daemon)
 			}
 		}
 	}

--- a/pkg/operator/ceph/cluster/monitoring.go
+++ b/pkg/operator/ceph/cluster/monitoring.go
@@ -24,6 +24,7 @@ import (
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 )
 
 var (
@@ -37,10 +38,10 @@ func (c *ClusterController) configureCephMonitoring(cluster *cluster, clusterInf
 		isEnabled = isMonitoringEnabled(daemon, cluster.Spec)
 		if health, ok := cluster.monitoringRoutines[daemon]; ok {
 			// If the context Err() is nil this means it hasn't been cancelled yet
-			if health.internalCtx.Err() == nil {
+			if health.InternalCtx.Err() == nil {
 				logger.Debugf("monitoring routine for %q is already running", daemon)
 				if !isEnabled {
-					cluster.monitoringRoutines[daemon].internalCancel()
+					cluster.monitoringRoutines[daemon].InternalCancel()
 				}
 			}
 		} else {
@@ -49,9 +50,9 @@ func (c *ClusterController) configureCephMonitoring(cluster *cluster, clusterInf
 				// They can individually be cancelled and will be cancelled when the parent context is cancelled
 				internalCtx, internalCancel := context.WithCancel(c.OpManagerCtx)
 
-				cluster.monitoringRoutines[daemon] = &clusterHealth{
-					internalCtx:    internalCtx,
-					internalCancel: internalCancel,
+				cluster.monitoringRoutines[daemon] = &opcontroller.ClusterHealth{
+					InternalCtx:    internalCtx,
+					InternalCancel: internalCancel,
 				}
 
 				// Run the go routine
@@ -81,18 +82,18 @@ func (c *ClusterController) startMonitoringCheck(cluster *cluster, clusterInfo *
 	case "mon":
 		healthChecker := mon.NewHealthChecker(cluster.mons)
 		logger.Infof("enabling ceph %s monitoring goroutine for cluster %q", daemon, cluster.Namespace)
-		go healthChecker.Check(cluster.monitoringRoutines[daemon].internalCtx)
+		go healthChecker.Check(cluster.monitoringRoutines, daemon)
 
 	case "osd":
 		if !cluster.Spec.External.Enable {
 			c.osdChecker = osd.NewOSDHealthMonitor(c.context, clusterInfo, cluster.Spec.RemoveOSDsIfOutAndSafeToRemove, cluster.Spec.HealthCheck)
 			logger.Infof("enabling ceph %s monitoring goroutine for cluster %q", daemon, cluster.Namespace)
-			go c.osdChecker.Start(cluster.monitoringRoutines[daemon].internalCtx)
+			go c.osdChecker.Start(cluster.monitoringRoutines, daemon)
 		}
 
 	case "status":
 		cephChecker := newCephStatusChecker(c.context, clusterInfo, cluster.Spec)
 		logger.Infof("enabling ceph %s monitoring goroutine for cluster %q", daemon, cluster.Namespace)
-		go cephChecker.checkCephStatus(cluster.monitoringRoutines[daemon].internalCtx)
+		go cephChecker.checkCephStatus(cluster.monitoringRoutines, daemon)
 	}
 }

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	testexec "github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -102,9 +103,15 @@ func TestOSDHealthCheck(t *testing.T) {
 
 func TestMonitorStart(t *testing.T) {
 	context, cancel := context.WithCancel(context.TODO())
+	monitoringRoutines := make(map[string]*opcontroller.ClusterHealth)
+	monitoringRoutines["osd"] = &opcontroller.ClusterHealth{
+		InternalCtx:    context,
+		InternalCancel: cancel,
+	}
+
 	osdMon := NewOSDHealthMonitor(&clusterd.Context{}, client.AdminTestClusterInfo("ns"), true, cephv1.CephClusterHealthCheckSpec{})
 	logger.Infof("starting osd monitor")
-	go osdMon.Start(context)
+	go osdMon.Start(monitoringRoutines, "osd")
 	cancel()
 }
 

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -42,6 +42,12 @@ type OperatorConfig struct {
 	Parameters        map[string]string
 }
 
+// ClusterHealth is passed to the various monitoring go routines to stop them when the context is cancelled
+type ClusterHealth struct {
+	InternalCtx    context.Context
+	InternalCancel context.CancelFunc
+}
+
 const (
 	// OperatorSettingConfigMapName refers to ConfigMap that configures rook ceph operator
 	OperatorSettingConfigMapName string = "rook-ceph-operator-config"

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -538,7 +538,7 @@ func (r *ReconcileCephObjectStore) startMonitoring(objectstore *cephv1.CephObjec
 	}
 
 	logger.Infof("starting rgw health checker for CephObjectStore %q", namespacedName.String())
-	go rgwChecker.checkObjectStore(r.objectStoreContexts[channelKey].internalCtx)
+	go rgwChecker.checkObjectStore(r.objectStoreContexts, channelKey)
 
 	// Set the monitoring flag so we don't start more than one go routine
 	r.objectStoreContexts[channelKey].started = true

--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -17,7 +17,6 @@ limitations under the License.
 package object
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -88,7 +87,7 @@ func newBucketChecker(
 }
 
 // checkObjectStore periodically checks the health of the cluster
-func (c *bucketChecker) checkObjectStore(context context.Context) {
+func (c *bucketChecker) checkObjectStore(objectStoreContexts map[string]*objectStoreHealth, channelKey string) {
 	// check the object store health immediately before starting the loop
 	err := c.checkObjectStoreHealth()
 	if err != nil {
@@ -97,11 +96,18 @@ func (c *bucketChecker) checkObjectStore(context context.Context) {
 	}
 
 	for {
+		// We must perform this check otherwise the case will check an index that does not exist anymore and
+		// we will get an invalid pointer error and the go routine will panic
+		if _, ok := objectStoreContexts[channelKey]; !ok {
+			logger.Infof("object store %q has been deleted. stopping monitoring of rgw endpoints", c.namespacedName.Name)
+			return
+		}
 		select {
-		case <-context.Done():
+		case <-objectStoreContexts[channelKey].internalCtx.Done():
 			// purge bucket and s3 user
 			// Needed for external mode where in converged everything goes away with the CR deletion
 			c.cleanupHealthCheck()
+			delete(objectStoreContexts, channelKey)
 			logger.Infof("stopping monitoring of rgw endpoints for object store %q", c.namespacedName.Name)
 			return
 


### PR DESCRIPTION
Previously, the struct maintaining the list of cluster was still
initialized with a cluster item. Then the monitoring check will see that
the cluster is part of the struct already and thus won't run the
monitoring go routine again.
Now each time we cancel the context, we also remove the cluster item
from the map so that when the controller runs again, the monitoring
struct is re-populated and the go routine runs and statuses are updated.

Closes: https://github.com/rook/rook/issues/9911
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 05506e7a6836ab27d75552cc14174e6cea274cc8)
(cherry picked from commit fc9278c0402a72ece60d26eefef9b4583f4b0888)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
