### PR TITLE
Bug 2074558: osd: only set kek to env var on encryption scenario

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -158,7 +158,8 @@ func configRawDevice(name string, context *clusterd.Context) (*sys.LocalDisk, er
 
 // Provision provisions an OSD
 func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topologyAffinity string) error {
-	if agent.pvcBacked {
+	if agent.pvcBacked && os.Getenv(oposd.EncryptedDeviceEnvVarName) == "true" {
+		logger.Debug("encryption configuration detecting, populating kek to an env variable")
 		// Init KMS store, retrieve the KEK and store it as an env var for ceph-volume
 		err := setKEKinEnv(context, agent.clusterInfo)
 		if err != nil {

--- a/pkg/daemon/ceph/osd/encryption.go
+++ b/pkg/daemon/ceph/osd/encryption.go
@@ -103,8 +103,7 @@ func setKEKinEnv(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo)
 		return errors.Wrap(err, "failed to set key encryption key env variable for ceph-volume")
 	}
 
-	logger.Debug("successfully set vault env variables")
-
+	logger.Debug("successfully set kek to env variable")
 	return nil
 }
 

--- a/pkg/daemon/ceph/osd/kms/envs.go
+++ b/pkg/daemon/ceph/osd/kms/envs.go
@@ -134,6 +134,7 @@ func ConfigEnvsToMapString() map[string]string {
 		pair := strings.SplitN(e, "=", 2)
 		for _, knownKMS := range knownKMSPrefix {
 			if strings.HasPrefix(pair[0], knownKMS) || pair[0] == Provider {
+				logger.Debugf("adding env %q", pair[0])
 				envs[pair[0]] = os.Getenv(pair[0])
 			}
 		}


### PR DESCRIPTION
There is a corner case where an env variable populated with the prepare
job could influence and trigger some encryption code. We have an env
variable to discover whether the prepare job will encrypt a drive or not
so let's use that instead of running code as a noop and sometimes
trigger a corner case. In this scenario, the prepare job had an "IBM_"
env variable present in the OS image (IBM OS) so the setKEKinEnv()
  function would get called for no reason.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 6bc7827150da5249a56bf7c10bc32c20ef23ee45)
(cherry picked from commit 8b1b68c7842d6702ecba1fe5108b3c22f0a64a55)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
