### PR TITLE
Bug 2092143: Delete ceph pool when blockpool cr is deleted and fix canary tests

### DIFF
--- a/.github/workflows/setup-cluster-resources/action.yaml
+++ b/.github/workflows/setup-cluster-resources/action.yaml
@@ -18,7 +18,7 @@ runs:
       with:
         minikube version: "v1.24.0"
         kubernetes version: "v1.23.0"
-        start args: --memory 6g --cpus=2 --addons ingress
+        start args: --memory 6g --cpus=2 --addons ingress --cni=calico
         github token: ${{ inputs.github-token }}
 
     - name: install deps

--- a/.github/workflows/setup-cluster-resources/action.yaml
+++ b/.github/workflows/setup-cluster-resources/action.yaml
@@ -18,7 +18,7 @@ runs:
       with:
         minikube version: "v1.24.0"
         kubernetes version: "v1.23.0"
-        start args: --memory 6g --cpus=2 --addons ingress --cni=flannel
+        start args: --memory 6g --cpus=2 --addons ingress
         github token: ${{ inputs.github-token }}
 
     - name: install deps

--- a/pkg/apis/ceph.rook.io/v1/pool_test.go
+++ b/pkg/apis/ceph.rook.io/v1/pool_test.go
@@ -37,11 +37,11 @@ func TestValidatePoolSpec(t *testing.T) {
 			},
 		},
 	}
-	err := validatePoolSpec(p.Spec.ToNamedPoolSpec())
+	err := validatePoolSpec(p.ToNamedPoolSpec())
 	assert.NoError(t, err)
 
 	p.Spec.ErasureCoded.DataChunks = 1
-	err = validatePoolSpec(p.Spec.ToNamedPoolSpec())
+	err = validatePoolSpec(p.ToNamedPoolSpec())
 	assert.Error(t, err)
 }
 

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -124,22 +124,27 @@ func TestCreatePool(t *testing.T) {
 func TestCephPoolName(t *testing.T) {
 	t.Run("spec not set", func(t *testing.T) {
 		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "metapool"}}
-		name := getCephName(p)
+		name := p.ToNamedPoolSpec().Name
 		assert.Equal(t, "metapool", name)
 	})
 	t.Run("same name already set", func(t *testing.T) {
 		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "metapool"}, Spec: cephv1.NamedBlockPoolSpec{Name: "metapool"}}
-		name := getCephName(p)
+		name := p.ToNamedPoolSpec().Name
 		assert.Equal(t, "metapool", name)
 	})
 	t.Run("override device metrics", func(t *testing.T) {
 		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "device-metrics"}, Spec: cephv1.NamedBlockPoolSpec{Name: "device_health_metrics"}}
-		name := getCephName(p)
+		name := p.ToNamedPoolSpec().Name
 		assert.Equal(t, "device_health_metrics", name)
+	})
+	t.Run("override mgr", func(t *testing.T) {
+		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "default-mgr"}, Spec: cephv1.NamedBlockPoolSpec{Name: ".mgr"}}
+		name := p.ToNamedPoolSpec().Name
+		assert.Equal(t, ".mgr", name)
 	})
 	t.Run("override nfs", func(t *testing.T) {
 		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "default-nfs"}, Spec: cephv1.NamedBlockPoolSpec{Name: ".nfs"}}
-		name := getCephName(p)
+		name := p.ToNamedPoolSpec().Name
 		assert.Equal(t, ".nfs", name)
 	})
 }

--- a/pkg/operator/ceph/pool/validate.go
+++ b/pkg/operator/ceph/pool/validate.go
@@ -20,7 +20,6 @@ package pool
 import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	v1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
@@ -35,7 +34,7 @@ func validatePool(context *clusterd.Context, clusterInfo *client.ClusterInfo, cl
 		return errors.New("missing namespace")
 	}
 
-	if err := v1.ValidateCephBlockPool(&p.Spec); err != nil {
+	if err := cephv1.ValidateCephBlockPool(p); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
During deletion of a CephBlockPool CR, the underlying ceph pool was not being deleted. During the deletion sequence this is due to the spec being refreshed upon a call to check for dependents in ReportDeletionNotBlockedDueToDependents(). The pool name was then coming up blank during the deletion request and rook of course then wasn't finding the pool to delete.

Now Rook properly sets the pool name in the named spec every time it is converted internally from a CephBlockPool type to a NamedPoolSpec.

Also backporting the fixes to the CI for the canary test CNI.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=2092143

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
