### PR TITLE
Bug 2098621:  core: delete v1beta1 cronjob only when v1 not found

### DIFF
--- a/pkg/operator/ceph/cluster/crash/reconcile.go
+++ b/pkg/operator/ceph/cluster/crash/reconcile.go
@@ -299,10 +299,8 @@ func (r *ReconcileNode) reconcileCrashRetention(namespace string, cephCluster ce
 		var cronJob client.Object
 		// minimum k8s version required for v1 cronJob is 'v1.21.0'. Apply v1 if k8s version is at least 'v1.21.0', else apply v1beta1 cronJob.
 		if useCronJobV1 {
-			// delete v1beta1 cronJob if it already exists
-			err = r.client.Delete(r.opManagerContext, &v1beta1.CronJob{ObjectMeta: objectMeta})
-			if err != nil && !kerrors.IsNotFound(err) {
-				return errors.Wrapf(err, "failed to delete CronJob v1beta1 %q", prunerName)
+			if err := r.deletev1betaJob(objectMeta); err != nil {
+				return err
 			}
 			cronJob = &v1.CronJob{ObjectMeta: objectMeta}
 		} else {


### PR DESCRIPTION
earlier we're deleting v1beta1 always before creating
v1 job. Now, we delete only when k8s version is
latest(which supports v1  job) and v1 job is not created
which means this is the first time and this is the only time we'll
delete v1beta1.

Signed-off-by: subhamkrai <srai@redhat.com>
(cherry picked from commit 196f5da6354eb9ef1626b6d85a0173fd5f1a8a7a)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
