### PR TITLE
Bug 2120601: mon: Improve mon failover reliability [4.10]

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -22,7 +22,11 @@ jobs:
       - name: codespell
         uses: codespell-project/actions-codespell@master
         with:
-          skip: .git,*.png,*.jpg,*.svg,*.sum
+          # LICENSE: skip file because codespell wants to flag complies, which we may want to flag
+          # in other places, so ignore the file itself assuming it is correct
+          # crds.yaml, resources.yaml: CRD files are fully generated from content we control (should
+          # be flagged elsewhere) and content we don't control (can't fix easily), so ignore
+          skip: .git,*.png,*.jpg,*.svg,*.sum,./LICENSE,./deploy/examples/crds.yaml,./deploy/charts/rook-ceph/templates/resources.yaml
           # aks: Amazon Kubernetes Service
           # keyserver: flag to apt-key
           # atleast: codespell wants to flag any 'AtLeast' method
@@ -32,6 +36,7 @@ jobs:
           # te: udev persistent naming test in pkg/daemon/ceph/osd/daemon_test.go
           # parm: modinfo parameter
           # assigment: inherited from K8s TopologySpreadConstraints dependency
-          ignore_words_list: aks,keyserver,atleast,ser,ist,ba,iam,te,parm,assigment
+          # ro, RO: means read-only
+          ignore_words_list: aks,keyserver,atleast,ser,ist,ba,iam,te,parm,assigment,ro,RO
           check_filenames: true
           check_hidden: true

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -70,7 +70,7 @@ cephClusterSpec:
 
   # WaitTimeoutForHealthyOSDInMinutes defines the time (in minutes) the operator would wait before an OSD can be stopped for upgrade or restart.
   # If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
-  # if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then opertor would
+  # if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would
   # continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
   # The default wait timeout is 10 minutes.
   waitTimeoutForHealthyOSDInMinutes: 10

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -39,7 +39,7 @@ spec:
   continueUpgradeAfterChecksEvenIfNotHealthy: false
   # WaitTimeoutForHealthyOSDInMinutes defines the time (in minutes) the operator would wait before an OSD can be stopped for upgrade or restart.
   # If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
-  # if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then opertor would
+  # if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would
   # continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
   # The default wait timeout is 10 minutes.
   waitTimeoutForHealthyOSDInMinutes: 10

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -60,7 +60,7 @@ allowHostNetwork: true
 # This need to be set to true as we use HostPath
 allowHostDirVolumePlugin: true
 priority:
-# SYS_ADMIN is needed for rbd to execture rbd map command
+# SYS_ADMIN is needed for rbd to execute rbd map command
 allowedCapabilities: ["SYS_ADMIN"]
 # Needed as we run liveness container on daemonset pods
 allowHostPorts: true

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -305,7 +305,7 @@ func (c *Cluster) checkHealth(ctx context.Context) error {
 			logger.Warningf("cannot reduce mon quorum size from 2 to 1")
 		} else {
 			logger.Infof("removing an extra mon. currently %d are in quorum and only %d are desired", len(quorumStatus.MonMap.Mons), desiredMonCount)
-			return c.removeMon(quorumStatus.MonMap.Mons[0].Name)
+			return c.removeMon(c.determineExtraMonToRemove())
 		}
 	}
 
@@ -324,6 +324,80 @@ func (c *Cluster) checkHealth(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// determineExtraMonToRemove assumes all mons are in quorum and that there are more mons
+// that required for desired state. One mon will be picked for removal in this priority:
+// 1. If a stretch cluster, remove the extra mon according to the stretch topology
+// 2. If more than one mon on a node, remove one of them
+// 3. If no criteria require for 1 or 2, pick an arbitrary mon
+func (c *Cluster) determineExtraMonToRemove() string {
+	mons := c.clusterInfoToMonConfig()
+	if c.spec.IsStretchCluster() {
+		stretchMonToRemove := c.findExtraMonToRemoveFromStretchCluster(mons)
+		if stretchMonToRemove != "" {
+			return stretchMonToRemove
+		}
+		logger.Infof("did not find an extra mon to remove from the stretch cluster")
+		return ""
+	}
+
+	nodesWithMons := map[string]string{}
+	arbitraryMon := ""
+	for _, mon := range mons {
+		if mon.NodeName == "" {
+			logger.Debugf("mon %q is not scheduled to a specific host", mon.DaemonName)
+			continue
+		}
+		// Check if there are multiple mons on the node
+		if existingMon, ok := nodesWithMons[mon.NodeName]; ok {
+			logger.Infof("found mons %q and %q on node %s, removing mon %q", existingMon, mon.DaemonName, mon.NodeName, mon.DaemonName)
+			return mon.DaemonName
+		}
+		nodesWithMons[mon.NodeName] = mon.DaemonName
+
+		// assign the current mon as the fallback mon
+		arbitraryMon = mon.DaemonName
+	}
+
+	logger.Infof("removing arbitrary extra mon %q", arbitraryMon)
+	return arbitraryMon
+}
+
+func (c *Cluster) findExtraMonToRemoveFromStretchCluster(mons []*monConfig) string {
+	// Build the count of current mons per zone
+	zoneCount := map[string]int{}
+	monInZones := map[string]string{}
+	for _, m := range mons {
+		if m.Zone == "" {
+			logger.Warningf("zone not found on mon %q", m.DaemonName)
+			continue
+		}
+		zoneCount[m.Zone]++
+		// We just need the name of one of the mons in the zone in case there are extra
+		monInZones[m.Zone] = m.DaemonName
+	}
+
+	// Find a zone that has too many mons
+	for _, zone := range c.spec.Mon.StretchCluster.Zones {
+		count, ok := zoneCount[zone.Name]
+		if !ok {
+			// The zone isn't currently assigned to any mon, so skip it
+			continue
+		}
+		if zone.Arbiter {
+			if count > 1 {
+				logger.Infof("removing extra mon %q in arbiter zone %q", monInZones[zone.Name], zone.Name)
+				return monInZones[zone.Name]
+			}
+		} else {
+			if count > 2 {
+				logger.Infof("removing extra mon %q in zone %q", monInZones[zone.Name], zone.Name)
+				return monInZones[zone.Name]
+			}
+		}
+	}
+	return ""
 }
 
 // failMon compares the monCount against desiredMonCount
@@ -444,25 +518,8 @@ func (c *Cluster) updateMonDeploymentReplica(name string, enabled bool) error {
 func (c *Cluster) failoverMon(name string) error {
 	logger.Infof("Failing over monitor %q", name)
 
-	// Scale down the failed mon to allow a new one to start
-	if err := c.updateMonDeploymentReplica(name, false); err != nil {
-		// attempt to continue with the failover even if the bad mon could not be stopped
-		logger.Warningf("failed to stop mon %q for failover. %v", name, err)
-	}
-	newMonSucceeded := false
-	defer func() {
-		if newMonSucceeded {
-			// do nothing if the new mon was started successfully, the deployment will anyway be deleted
-			return
-		}
-		if err := c.updateMonDeploymentReplica(name, true); err != nil {
-			// attempt to continue even if the bad mon could not be restarted
-			logger.Warningf("failed to restart failed mon %q after new mon wouldn't start. %v", name, err)
-		}
-	}()
-
 	// remove the failed mon from a local list of the existing mons for finding a stretch zone
-	existingMons := c.clusterInfoToMonConfig(name)
+	existingMons := c.clusterInfoToMonConfigWithExclude(name)
 
 	zone, err := c.findAvailableZoneIfStretched(existingMons)
 	if err != nil {
@@ -473,9 +530,40 @@ func (c *Cluster) failoverMon(name string) error {
 	m := c.newMonConfig(c.maxMonID+1, zone)
 	logger.Infof("starting new mon: %+v", m)
 
-	mConf := []*monConfig{m}
+	// Scale down the failed mon to allow a new one to start
+	if err := c.updateMonDeploymentReplica(name, false); err != nil {
+		// attempt to continue with the failover even if the bad mon could not be stopped
+		logger.Warningf("failed to stop mon %q for failover. %v", name, err)
+	}
+
+	// If the mon failover is not successful, revert the failover
+	newMonSucceeded := false
+	newMonMightBeInQuorum := false
+	defer func() {
+		if newMonSucceeded {
+			// do nothing if the new mon was started successfully, the deployment will anyway be deleted
+			return
+		}
+		logger.Warningf("failover of mon %q unsuccessful, cleaning up replacement mon %q", name, m.DaemonName)
+		if err := c.updateMonDeploymentReplica(name, true); err != nil {
+			// attempt to continue even if the bad mon could not be restarted
+			logger.Warningf("failed to restart failed mon %q after new mon wouldn't start. %v", name, err)
+		}
+		if err := c.removeMonWithOptionalQuorum(m.DaemonName, newMonMightBeInQuorum); err != nil {
+			logger.Infof("failed to remove mon %q from quorum. %v", m.DaemonName, err)
+		}
+
+		// Make sure the maxMonID is reverted to its previous value
+		// The maxMonId is committed to a configmap immediately after the mon deployment
+		// is started, even though c.maxMonID is not incremented until the mon failover is successful
+		logger.Infof("reverting maxMonId to %d", c.maxMonID)
+		if err := c.commitMaxMonIDRequireIncrementing(c.maxMonID, false); err != nil {
+			logger.Errorf("failed to revert maxMonId after starting mon %q", m.DaemonName)
+		}
+	}()
 
 	// Assign the pod to a node
+	mConf := []*monConfig{m}
 	if err := c.assignMons(mConf); err != nil {
 		return errors.Wrap(err, "failed to place new mon on a node")
 	}
@@ -497,6 +585,7 @@ func (c *Cluster) failoverMon(name string) error {
 	c.ClusterInfo.Monitors[m.DaemonName] = cephclient.NewMonInfo(m.DaemonName, m.PublicIP, m.Port)
 
 	// Start the deployment
+	newMonMightBeInQuorum = true
 	if err := c.startDeployments(mConf, true); err != nil {
 		return errors.Wrapf(err, "failed to start new mon %s", m.DaemonName)
 	}
@@ -518,6 +607,15 @@ func (c *Cluster) failoverMon(name string) error {
 
 // make a best effort to remove the mon and all its resources
 func (c *Cluster) removeMon(daemonName string) error {
+	return c.removeMonWithOptionalQuorum(daemonName, true)
+}
+
+// make a best effort to remove the mon and all its resources
+func (c *Cluster) removeMonWithOptionalQuorum(daemonName string, shouldRemoveFromQuorum bool) error {
+	if daemonName == "" {
+		logger.Info("did not identify a mon to remove")
+		return nil
+	}
 	logger.Infof("ensuring removal of unhealthy monitor %s", daemonName)
 
 	resourceName := resourceName(daemonName)
@@ -535,8 +633,10 @@ func (c *Cluster) removeMon(daemonName string) error {
 	}
 
 	// Remove the bad monitor from quorum
-	if err := c.removeMonitorFromQuorum(daemonName); err != nil {
-		logger.Errorf("failed to remove mon %q from quorum. %v", daemonName, err)
+	if shouldRemoveFromQuorum {
+		if err := c.removeMonitorFromQuorum(daemonName); err != nil {
+			logger.Errorf("failed to remove mon %q from quorum. %v", daemonName, err)
+		}
 	}
 	delete(c.ClusterInfo.Monitors, daemonName)
 

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -153,6 +153,62 @@ func TestCheckHealth(t *testing.T) {
 	}
 }
 
+func TestRemoveExtraMon(t *testing.T) {
+	endpoint := "1.2.3.4:6789"
+	c := &Cluster{mapping: &Mapping{}}
+	c.ClusterInfo = &cephclient.ClusterInfo{Monitors: map[string]*cephclient.MonInfo{
+		"a": {Name: "a", Endpoint: endpoint},
+		"b": {Name: "b", Endpoint: endpoint},
+		"c": {Name: "c", Endpoint: endpoint},
+		"d": {Name: "d", Endpoint: endpoint},
+	}}
+	c.mapping.Schedule = map[string]*MonScheduleInfo{
+		"a": {Name: "node1"},
+		"b": {Name: "node2"},
+		"c": {Name: "node3"},
+		"d": {Name: "node1"},
+	}
+	// Remove mon an extra mon on the same node
+	removedMon := c.determineExtraMonToRemove()
+	if removedMon != "a" && removedMon != "d" {
+		assert.Fail(t, fmt.Sprintf("removed mon %q instead of a or d", removedMon))
+	}
+
+	// Remove an arbitrary mon that are all on different nodes
+	c.mapping.Schedule["d"].Name = "node4"
+	removedMon = c.determineExtraMonToRemove()
+	assert.NotEqual(t, "", removedMon)
+
+	// Don't remove any extra mon from a proper stretch cluster
+	c.spec.Mon.StretchCluster = &cephv1.StretchClusterSpec{Zones: []cephv1.StretchClusterZoneSpec{
+		{Name: "x", Arbiter: true},
+		{Name: "y"},
+		{Name: "z"},
+	}}
+	c.ClusterInfo.Monitors["e"] = &cephclient.MonInfo{Name: "e", Endpoint: endpoint}
+	c.mapping.Schedule["a"].Zone = "x"
+	c.mapping.Schedule["b"].Zone = "y"
+	c.mapping.Schedule["c"].Zone = "y"
+	c.mapping.Schedule["d"].Zone = "z"
+	c.mapping.Schedule["e"] = &MonScheduleInfo{Name: "node5", Zone: "z"}
+	removedMon = c.determineExtraMonToRemove()
+	assert.Equal(t, "", removedMon)
+
+	// Remove an extra mon from the arbiter zone
+	c.mapping.Schedule["d"].Zone = "x"
+	removedMon = c.determineExtraMonToRemove()
+	if removedMon != "a" && removedMon != "d" {
+		assert.Fail(t, "removed mon %q instead of a or d from the arbiter zone", removedMon)
+	}
+
+	// Remove an extra mon from a non-arbiter zone
+	c.mapping.Schedule["d"].Zone = "y"
+	removedMon = c.determineExtraMonToRemove()
+	if removedMon != "b" && removedMon != "c" && removedMon != "d" {
+		assert.Fail(t, fmt.Sprintf("removed mon %q instead of b, c, or d from the non-arbiter zone", removedMon))
+	}
+}
+
 func TestSkipMonFailover(t *testing.T) {
 	c := New(&clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)

--- a/tests/framework/utils/exec_utils.go
+++ b/tests/framework/utils/exec_utils.go
@@ -29,7 +29,7 @@ import (
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "testutil")
 
-// CommandArgs is a warpper for cmd args
+// CommandArgs is a wrapper for cmd args
 type CommandArgs struct {
 	Command             string
 	CmdArgs             []string


### PR DESCRIPTION
Mon failover reliability is improved in two scenarios with these changes.
First, if the failover is aborted because of failing to start the new mon
and wait for it to join quorum, the new mon will be fully removed and
the failover rolled back. Previously, the operator would leave the new
mon pod running even if it never joined quorum. Now the timeout for the failover
is increased to wait longer for the new mon, but if it times out, there
are no leftovers from the cancelled failover.

Second, if the operator is failed in the middle of a failover
before the old mon is removed, the operator needs to remove an extra
mon. The operator was only selecting a random mon for removal instead
of honoring the stretch cluster topology or looking for mons
on the same node that could be removed to restore the correct
desired number of mons.

Signed-off-by: Travis Nielsen <tnielsen@redhat.com>
(cherry picked from commit 72a4245fbfb3761c83b2318285e54396ce95ffcc)
(cherry picked from commit 3212876f2cad8f9b755378278f4ffc94f83dabb1)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=2120601

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
