### PR TITLE
Bug 2130110: external: do not add info=read cap if ceph version doesn't support it

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -1086,7 +1086,7 @@ class RadosJSON:
             "--display-name",
             "Rook RGW Admin Ops user",
             "--caps",
-            "info=read;buckets=*;users=*;usage=read;metadata=read;zone=read",
+            "buckets=*;users=*;usage=read;metadata=read;zone=read",
         ]
         if self._arg_parser.dry_run:
             return self.dry_run("ceph " + " ".join(cmd))
@@ -1117,7 +1117,7 @@ class RadosJSON:
                 )
                 raise Exception(err_msg)
 
-        # separately add info=read caps, because sometimes users already exited and the cap doesn't update
+        # separately add info=read caps for rgw-endpoint ip validation
         info_cap_supported = True
         cmd = [
             "radosgw-admin",


### PR DESCRIPTION
The rgw ip validation feature was needing to update the rgw user cap to add info=read permission, but this permission is only backported till ceph pacific, so we added a check that only add this cap when ceph version support it,
But this cap was also adding with the other caps, so removed it from there Now it will only add this cap if ceph version support it

Signed-off-by: parth-gr <paarora@redhat.com>
(cherry picked from commit 54425803b6cb6fa1e0896cc1e81850631b02e15b) (cherry picked from commit 32e4160971b0b152ce9235b2fd2532d7381f7bdf)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
