### PR TITLE
BUG 2128587: csi: make sure we reset CSIParam booleans to default

### DIFF
--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -143,28 +143,28 @@ func (r *ReconcileCSI) setParams(ver *version.Info) error {
 	// critical pods in cluster but less priority than plugin pods
 	CSIParam.ProvisionerPriorityClassName = k8sutil.GetValue(r.opConfig.Parameters, "CSI_PROVISIONER_PRIORITY_CLASSNAME", "")
 
+	CSIParam.EnableOMAPGenerator = false
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_OMAP_GENERATOR", "false"), "true") {
 		CSIParam.EnableOMAPGenerator = true
 	}
 
 	// SA token projection is stable only from kubernetes version 1.20.
+	CSIParam.EnableOIDCTokenProjection = false
 	if ver.Major == KubeMinMajor && ver.Minor >= KubeMinVerForOIDCTokenProjection {
 		CSIParam.EnableOIDCTokenProjection = true
 	}
 
-	// enable RBD, CephFS and NFS snapshotter by default
 	CSIParam.EnableRBDSnapshotter = true
-	CSIParam.EnableCephFSSnapshotter = true
-	CSIParam.EnableNFSSnapshotter = true
-
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_RBD_SNAPSHOTTER", "true"), "false") {
 		CSIParam.EnableRBDSnapshotter = false
 	}
 
+	CSIParam.EnableCephFSSnapshotter = true
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_CEPHFS_SNAPSHOTTER", "true"), "false") {
 		CSIParam.EnableCephFSSnapshotter = false
 	}
 
+	CSIParam.EnableNFSSnapshotter = true
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_NFS_SNAPSHOTTER", "true"), "false") {
 		CSIParam.EnableNFSSnapshotter = false
 	}
@@ -179,10 +179,12 @@ func (r *ReconcileCSI) setParams(ver *version.Info) error {
 		CSIParam.EnableCSITopology = true
 	}
 
+	CSIParam.EnableCSIEncryption = false
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_ENCRYPTION", "false"), "true") {
 		CSIParam.EnableCSIEncryption = true
 	}
 
+	CSIParam.CSIEnableMetadata = false
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_METADATA", "false"), "true") {
 		CSIParam.CSIEnableMetadata = true
 	}
@@ -205,6 +207,7 @@ func (r *ReconcileCSI) setParams(ver *version.Info) error {
 		CSIParam.RBDPluginUpdateStrategy = rollingUpdate
 	}
 
+	CSIParam.EnablePluginSelinuxHostMount = false
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_PLUGIN_ENABLE_SELINUX_HOST_MOUNT", "false"), "true") {
 		CSIParam.EnablePluginSelinuxHostMount = true
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

On removing or setting params to false in operator config map, make sure to set CSIParam to their appropriate defaults, since we are not restarting the operator we cannot just assume these params/variables/flags are defaulted, everytime we need to makesure some defaults are specified.

This is what happens without these changes:
* Set CSI_ENABLE_METADATA to true, this will tune CSIParam.CSIEnableMetadata to true from false
* Create a PVC and check the metadata is added to the rbd/cephfs volumes
* Now Set CSI_ENABLE_METADATA to false, we assume CSIParam.CSIEnableMetadata will be set to false, but that is not happening because the earlier value of `CSIParam.CSIEnableMetadata = true` still persist. (we are not restarting operator to assume value of CSIParam.CSIEnableMetadata to be reset to false)

This happens with CSI_ENABLE_OMAP_GENERATOR and many other flags too, fixing them all with these changes.

Thanks to Madhu for debugging the issue and testing it along.

Credit: Madhu Rajanna \<madhupr007@gmail.com\>
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>
(cherry picked from commit bf3a3aa92ebe44ca6328a9735c495e434f198608)


**Which issue is resolved by this Pull Request:**
Resolves # https://bugzilla.redhat.com/show_bug.cgi?id=2128587
