### PR TITLE
Bug 2130497: osd: use 256 as cryptographicLength for keys using kmip kms

### DIFF
--- a/pkg/daemon/ceph/osd/kms/kmip.go
+++ b/pkg/daemon/ceph/osd/kms/kmip.go
@@ -48,7 +48,7 @@ const (
 	kmipDefaultWriteTimeout = uint8(10)
 
 	// cryptographicLength of the key.
-	cryptographicLength = 128
+	cryptographicLength = 256
 
 	//nolint:gosec, value not credential, just configuration keys.
 	kmipEndpoint         = "KMIP_ENDPOINT"


### PR DESCRIPTION
This commit changes cryptographic length for keys created
for kmip kms to 256 from 128, since it is more secure.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit https://github.com/red-hat-storage/rook/commit/9d0d93472ff601a0150371b8b62aeb8747348a55)
(cherry picked from commit https://github.com/red-hat-storage/rook/commit/0cf3af7a376bf09d1357275c33625e993e5d64a1)