### PR TITLE
Bug 2130279: ceph: fixing ClientID of log-collector for RGW instance

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -112,7 +112,7 @@ func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) (v1.PodTemplateSpec
 	if c.clusterSpec.LogCollector.Enabled {
 		shareProcessNamespace := true
 		podSpec.ShareProcessNamespace = &shareProcessNamespace
-		podSpec.Containers = append(podSpec.Containers, *controller.LogCollectorContainer(strings.TrimPrefix(generateCephXUser(fmt.Sprintf("ceph-client.%s", rgwConfig.ResourceName)), "client."), c.clusterInfo.Namespace, *c.clusterSpec))
+		podSpec.Containers = append(podSpec.Containers, *controller.LogCollectorContainer(getDaemonName(rgwConfig), c.clusterInfo.Namespace, *c.clusterSpec))
 	}
 
 	// Replace default unreachable node toleration
@@ -627,4 +627,8 @@ func (c *clusterConfig) rgwTLSSecretType(secretName string) (v1.SecretType, erro
 		return rgwTlsSecret.Type, nil
 	}
 	return "", errors.Wrapf(err, "no Kubernetes secrets referring TLS certificates found")
+}
+
+func getDaemonName(rgwConfig *rgwConfig) string {
+	return fmt.Sprintf("ceph-%s", generateCephXUser(rgwConfig.ResourceName))
 }

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -380,3 +380,33 @@ func TestCheckRGWKMS(t *testing.T) {
 	assert.True(t, b)
 	assert.NoError(t, err)
 }
+
+func TestGetDaemonName(t *testing.T) {
+	context := &clusterd.Context{Clientset: test.New(t, 3)}
+	store := simpleStore()
+	tests := []struct {
+		storeName      string
+		testDaemonName string
+		daemonID       string
+	}{
+		{"default", "ceph-client.rgw.default.a", "a"},
+		{"my-store", "ceph-client.rgw.my.store.b", "b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.storeName, func(t *testing.T) {
+			c := &clusterConfig{
+				context: context,
+				store:   store,
+			}
+			c.store.Name = tt.storeName
+			daemonName := fmt.Sprintf("%s-%s", c.store.Name, tt.daemonID)
+			resourceName := fmt.Sprintf("%s-%s", AppName, daemonName)
+			rgwconfig := &rgwConfig{
+				ResourceName: resourceName,
+				DaemonID:     daemonName,
+			}
+			daemon := getDaemonName(rgwconfig)
+			assert.Equal(t, tt.testDaemonName, daemon)
+		})
+	}
+}


### PR DESCRIPTION
The Client_ID generated by operator was
different from the log rotate file created
The Clinet_ID= rgwceph.client.rook.ceph.rgw.my.store.a and log file name= ceph-client.rgw.my.store.a.log
So changed the CLient_ID to ceph-client.rgw.my.store.a for correct working and this follow the patterns how other modules Client_ID is generated

Closes: https://github.com/rook/rook/issues/8692
Signed-off-by: parth-gr <paarora@redhat.com>
(cherry picked from commit fc7905a7bd37529c7e3e1be5e96bc3b2a507b543)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
