### PR TITLE
Bug 2143899: core: Parse peer pool ouput with --out-file flag

### DIFF
--- a/pkg/operator/ceph/csi/peermap/config_test.go
+++ b/pkg/operator/ceph/csi/peermap/config_test.go
@@ -18,6 +18,9 @@ package peermap
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -235,6 +238,23 @@ var fakeMultiPeerCephBlockPool = cephv1.CephBlockPool{
 	},
 }
 
+func saveMockDataInTempFile(data, filePattern string) error {
+	matches, _ := filepath.Glob(fmt.Sprintf("/tmp/%s*", filePattern))
+	for _, m := range matches {
+		file, err := os.OpenFile(m, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to open file %q. %v", m, err)
+		}
+
+		defer file.Close()
+		_, err = file.WriteString(data)
+		if err != nil {
+			return fmt.Errorf("failed to write data to the file %q. %v", m, err)
+		}
+	}
+	return nil
+}
+
 var mockExecutor = &exectest.MockExecutor{
 	MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
@@ -253,22 +273,46 @@ var mockExecutor = &exectest.MockExecutor{
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "osd" && args[1] == "pool" && args[2] == "get" && strings.HasSuffix(args[5], "peer1") {
 			if args[3] == "mirrorPool1" {
+				err := saveMockDataInTempFile(`{"pool_id": 2}`, peerPoolTempFile)
+				if err != nil {
+					return "", err
+				}
 				return `{"pool_id": 2}`, nil
 			} else if args[3] == "mirrorPool2" {
+				err := saveMockDataInTempFile(`{"pool_id": 3}`, peerPoolTempFile)
+				if err != nil {
+					return "", err
+				}
 				return `{"pool_id": 3}`, nil
 			}
 		}
 		if args[0] == "osd" && args[1] == "pool" && args[2] == "get" && strings.HasSuffix(args[5], "peer2") {
 			if args[3] == "mirrorPool1" {
+				err := saveMockDataInTempFile(`{"pool_id": 3}`, peerPoolTempFile)
+				if err != nil {
+					return "", err
+				}
 				return `{"pool_id": 3}`, nil
 			} else if args[3] == "mirrorPool2" {
+				err := saveMockDataInTempFile(`{"pool_id": 4}`, peerPoolTempFile)
+				if err != nil {
+					return "", err
+				}
 				return `{"pool_id": 4}`, nil
 			}
 		}
 		if args[0] == "osd" && args[1] == "pool" && args[2] == "get" && strings.HasSuffix(args[5], "peer3") {
 			if args[3] == "mirrorPool1" {
+				err := saveMockDataInTempFile(`{"pool_id": 4}`, peerPoolTempFile)
+				if err != nil {
+					return "", err
+				}
 				return `{"pool_id": 4}`, nil
 			} else if args[3] == "mirrorPool2" {
+				err := saveMockDataInTempFile(`{"pool_id": 5}`, peerPoolTempFile)
+				if err != nil {
+					return "", err
+				}
 				return `{"pool_id": 5}`, nil
 			}
 		}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When mirror logs are enabled, `ceph osd pool get <poolname> all` command returns peer pool info along with the debug logs. This causes error while parsing the logs for json data. Using --out-file flag saves the json data in the file which can be parsed easily while logging will still be written to stdout/stderr.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=2143899

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
