### PR TITLE
Bug 2150410: core: Set env var for ceph msgr to use random nonce

### DIFF
--- a/pkg/operator/ceph/test/containers.go
+++ b/pkg/operator/ceph/test/containers.go
@@ -30,7 +30,7 @@ var requiredEnvVars = []string{
 	"CONTAINER_IMAGE", "POD_NAME", "POD_NAMESPACE", "NODE_NAME",
 	"ROOK_CEPH_MON_HOST", "ROOK_CEPH_MON_INITIAL_MEMBERS",
 	"POD_CPU_LIMIT", "POD_MEMORY_LIMIT", "POD_MEMORY_REQUEST",
-	"POD_CPU_REQUEST",
+	"POD_CPU_REQUEST", "CEPH_USE_RANDOM_NONCE",
 }
 
 // A ContainersTester is a helper exposing methods for testing required Ceph specifications common
@@ -130,6 +130,9 @@ func (ct *ContainersTester) AssertEnvVarsContainCephRequirements() {
 			case "POD_CPU_REQUEST":
 				assert.Equal(ct.t, "requests.cpu", e.ValueFrom.ResourceFieldRef.Resource,
 					"POD_CPU_REQUEST env var does not have the appropriate source:", e)
+			case "CEPH_USE_RANDOM_NONCE":
+				assert.Equal(ct.t, "true", e.Value,
+					"CEPH_USE_RANDOM_NONCE env var does not have the appropriate source:", e)
 			}
 		}
 		vars := FindDuplicateEnvVars(c)

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -305,6 +305,9 @@ func ClusterDaemonEnvVars(image string) []v1.EnvVar {
 		// If request.cpu is not set in the pod definition, Kubernetes will use the formula "requests.cpu = limits.cpu" during pods's scheduling
 		// Kubernetes will set this variable to 0 or equal to limits.cpu if set
 		{Name: "POD_CPU_REQUEST", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{Resource: "requests.cpu"}}},
+
+		// All ceph daemons using msgr in a containerized environment expect to set a random nonce at startup
+		{Name: "CEPH_USE_RANDOM_NONCE", Value: "true"},
 	}
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Ceph will use a random nonce for the msgr daemons as long as they are running as PID 1 or have the environment variable CEPH_USE_RANDOM_NONCE set to indicate running in a containerized environment. While the Ceph daemons in Rook are expected to run in PID 1, there are some environments where the container runtime may choose to run something else such as /usr/bin/pod as PID 1. The side effect then is that ceph uses the pid as the nonce and causes problems when the daemons restart with the same PID.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=2150410

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
