### PR TITLE
Bug 2148567: osd: Allow mpath_member filesystem for mpath disks

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -370,6 +370,8 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 				// This handles the case where the OSD deployment has been removed and the prepare
 				// job kicks in again to re-deploy the OSD.
 				continue
+			} else if device.Filesystem == "mpath_member" && agent.pvcBacked {
+				logger.Infof("allowing multipath disk %q with filesystem %q", device.Name, device.Filesystem)
 			} else {
 				logger.Infof("skipping device %q because it contains a filesystem %q", device.Name, device.Filesystem)
 				continue

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -290,5 +290,6 @@ func legacyDeviceSetPVCID(deviceSetName string, setIndex int) string {
 // It includes the pvcTemplateName in it
 func deviceSetPVCID(deviceSetName, pvcTemplateName string, setIndex int) string {
 	cleanName := strings.Replace(pvcTemplateName, " ", "-", -1)
+	deviceSetName = strings.Replace(deviceSetName, ".", "-", -1)
 	return fmt.Sprintf("%s-%s-%d", deviceSetName, cleanName, setIndex)
 }

--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -270,3 +270,17 @@ func TestPrepareDeviceSetsWithCrushParams(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(pvcs.Items))
 }
+
+func TestPVCName(t *testing.T) {
+	id := deviceSetPVCID("mydeviceset", "a", 0)
+	assert.Equal(t, "mydeviceset-a-0", id)
+
+	id = deviceSetPVCID("mydeviceset", "a", 10)
+	assert.Equal(t, "mydeviceset-a-10", id)
+
+	id = deviceSetPVCID("device-set", "a", 10)
+	assert.Equal(t, "device-set-a-10", id)
+
+	id = deviceSetPVCID("device.set.with.dots", "b", 10)
+	assert.Equal(t, "device-set-with-dots-b-10", id)
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Multipath devices may have an FSTYPE=mpath_member even though a valid device for creating an OSD. The device will be allowed in this case when creating the OSD on a PV since it is a device specifically provisioned for the OSD. Allow a `.` in the storageClassDeviceSet name to avoid failing the creation of the OSD prepare job.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=2148567

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
