### PR TITLE
BUG 2153675: osd: Fix osd-prepare-job for encrypted cluster

### DIFF
--- a/pkg/daemon/ceph/osd/encryption.go
+++ b/pkg/daemon/ceph/osd/encryption.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	v1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -31,8 +32,9 @@ import (
 )
 
 const (
-	cryptsetupBinary = "cryptsetup"
-	dmsetupBinary    = "dmsetup"
+	cryptsetupBinary   = "cryptsetup"
+	dmsetupBinary      = "dmsetup"
+	luksOpenCmdTimeOut = 90 * time.Second
 )
 
 var (
@@ -136,6 +138,16 @@ func dumpLUKS(context *clusterd.Context, disk string) (string, error) {
 	}
 
 	return cryptsetupOut, nil
+}
+
+func openEncryptedDevice(context *clusterd.Context, disk, target, passphrase string) error {
+	args := []string{"luksOpen", "--verbose", "--allow-discards", disk, target}
+	err := context.Executor.ExecuteCommandWithStdin(luksOpenCmdTimeOut, cryptsetupBinary, &passphrase, args...)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open encrypted device %q", disk)
+	}
+
+	return nil
 }
 
 func isCephEncryptedBlock(context *clusterd.Context, currentClusterFSID string, disk string) bool {

--- a/pkg/daemon/ceph/osd/encryption.go
+++ b/pkg/daemon/ceph/osd/encryption.go
@@ -32,9 +32,10 @@ import (
 )
 
 const (
-	cryptsetupBinary   = "cryptsetup"
-	dmsetupBinary      = "dmsetup"
-	luksOpenCmdTimeOut = 90 * time.Second
+	cryptsetupBinary                = "cryptsetup"
+	dmsetupBinary                   = "dmsetup"
+	luksOpenCmdTimeOut              = 90 * time.Second
+	removeEncryptedDeviceCmdTimeOut = 30 * time.Second
 )
 
 var (
@@ -146,6 +147,18 @@ func openEncryptedDevice(context *clusterd.Context, disk, target, passphrase str
 	if err != nil {
 		return errors.Wrapf(err, "failed to open encrypted device %q", disk)
 	}
+
+	return nil
+}
+
+func removeEncryptedDevice(context *clusterd.Context, target string) error {
+	args := []string{"remove", "--force", target}
+	output, err := context.Executor.ExecuteCommandWithTimeout(removeEncryptedDeviceCmdTimeOut, "dmsetup", args...)
+	// ignore error if no device was found.
+	if err != nil {
+		return errors.Wrapf(err, "failed to remove dm device %q: %q", target, output)
+	}
+	logger.Debugf("successfully removed stale dm device %q", target)
 
 	return nil
 }

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -984,17 +984,32 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 				}
 			}
 			if encryptedBlock == "" {
-				// The encrypted block is not opened, this is an extreme corner case
-				// The OSD deployment has been removed manually AND the node rebooted
-				// So we need to re-open the block to re-hydrate the OSDInfo.
-				//
-				// Handling this case would mean, writing the encryption key on a temporary file, then call
-				// luksOpen to open the encrypted block and then call ceph-volume to list against the opened
-				// encrypted block.
-				// We don't implement this, yet and return an error.
-				return nil, errors.Errorf("failed to find the encrypted block device for %q, not opened?", block)
-			}
+				// The encrypted block is not opened.
+				// The encrypted device is closed in some cases when
+				// the OSD deployment has been removed manually accompanied
+				// by any of following cases:
+				// - node reboot
+				// - csi managed PVC being unmounted etc
+				// Let's re-open the block to re-hydrate the OSDInfo.
+				logger.Debugf("encrypted block device %q is not open, opening it now", block)
+				passphrase := os.Getenv(oposd.CephVolumeEncryptedKeyEnvVarName)
+				if passphrase == "" {
+					return nil, errors.Errorf("encryption passphrase is empty in env var %q", oposd.CephVolumeEncryptedKeyEnvVarName)
+				}
+				pvcName := os.Getenv(oposd.PVCNameEnvVarName)
+				if pvcName == "" {
+					return nil, errors.Errorf("pvc name is empty in env var %q", oposd.PVCNameEnvVarName)
+				}
 
+				target := oposd.EncryptionDMName(pvcName, oposd.DmcryptBlockType)
+				err = openEncryptedDevice(context, block, target, passphrase)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to open encrypted block device %q on %q", block, target)
+				}
+
+				// ceph-volume prefers to use /dev/mapper/<name>
+				encryptedBlock = oposd.EncryptionDMPath(pvcName, oposd.DmcryptBlockType)
+			}
 			// If we have one child device, it should be the encrypted block but still verifying it
 			isDeviceEncrypted, err := sys.IsDeviceEncrypted(context.Executor, encryptedBlock)
 			if err != nil {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -1002,6 +1002,11 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 				}
 
 				target := oposd.EncryptionDMName(pvcName, oposd.DmcryptBlockType)
+				// remove stale dm device left by previous OSD.
+				err = removeEncryptedDevice(context, target)
+				if err != nil {
+					logger.Warningf("failed to remove stale dm device %q: %q", target, err)
+				}
 				err = openEncryptedDevice(context, block, target, passphrase)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to open encrypted block device %q on %q", block, target)

--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -46,12 +46,12 @@ func encryptionKeyPath() string {
 	return path.Join(opconfig.EtcCephDir, encryptionKeyFileName)
 }
 
-func encryptionDMName(pvcName, blockType string) string {
+func EncryptionDMName(pvcName, blockType string) string {
 	return fmt.Sprintf("%s-%s", pvcName, blockType)
 }
 
-func encryptionDMPath(pvcName, blockType string) string {
-	return path.Join("/dev/mapper", encryptionDMName(pvcName, blockType))
+func EncryptionDMPath(pvcName, blockType string) string {
+	return path.Join("/dev/mapper", EncryptionDMName(pvcName, blockType))
 }
 
 func encryptionBlockDestinationCopy(mountPath, blockType string) string {

--- a/pkg/operator/ceph/cluster/osd/config_test.go
+++ b/pkg/operator/ceph/cluster/osd/config_test.go
@@ -50,11 +50,11 @@ func TestEncryptionBlockDestinationCopy(t *testing.T) {
 }
 
 func TestEncryptionDMPath(t *testing.T) {
-	assert.Equal(t, "/dev/mapper/set1-data-0-6rqdn-block-dmcrypt", encryptionDMPath("set1-data-0-6rqdn", DmcryptBlockType))
+	assert.Equal(t, "/dev/mapper/set1-data-0-6rqdn-block-dmcrypt", EncryptionDMPath("set1-data-0-6rqdn", DmcryptBlockType))
 }
 
 func TestEncryptionDMName(t *testing.T) {
-	assert.Equal(t, "set1-data-0-6rqdn-block-dmcrypt", encryptionDMName("set1-data-0-6rqdn", DmcryptBlockType))
+	assert.Equal(t, "set1-data-0-6rqdn-block-dmcrypt", EncryptionDMName("set1-data-0-6rqdn", DmcryptBlockType))
 }
 
 func TestClusterIsCephVolumeRAwModeSupported(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -858,7 +858,7 @@ func (c *Cluster) generateEncryptionOpenBlockContainer(resources v1.ResourceRequ
 		Command: []string{
 			"/bin/bash",
 			"-c",
-			fmt.Sprintf(openEncryptedBlock, c.clusterInfo.FSID, pvcName, encryptionKeyPath(), encryptionBlockDestinationCopy(mountPath, blockType), encryptionDMName(pvcName, cryptBlockType), encryptionDMPath(pvcName, cryptBlockType)),
+			fmt.Sprintf(openEncryptedBlock, c.clusterInfo.FSID, pvcName, encryptionKeyPath(), encryptionBlockDestinationCopy(mountPath, blockType), EncryptionDMName(pvcName, cryptBlockType), EncryptionDMPath(pvcName, cryptBlockType)),
 		},
 		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, volumeMountPVCName), getDeviceMapperMount()},
 		SecurityContext: controller.PrivilegedContext(true),
@@ -943,7 +943,7 @@ func (c *Cluster) generateEncryptionCopyBlockContainer(resources v1.ResourceRequ
 		Command: []string{
 			"/bin/bash",
 			"-c",
-			fmt.Sprintf(blockDevMapper, encryptionDMPath(pvcName, blockType), path.Join(mountPath, blockName)),
+			fmt.Sprintf(blockDevMapper, EncryptionDMPath(pvcName, blockType), path.Join(mountPath, blockName)),
 		},
 		// volumeMountPVCName is crucial, especially when the block we copy is the metadata block
 		// its value must be the name of the block PV so that all init containers use the same bridge (the emptyDir shared by all the init containers)
@@ -1165,7 +1165,7 @@ func (c *Cluster) getExpandEncryptedPVCInitContainer(mountPath string, osdProps 
 		Command: []string{
 			"cryptsetup",
 		},
-		Args:            []string{"--verbose", "resize", encryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
+		Args:            []string{"--verbose", "resize", EncryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
 		VolumeMounts:    volMount,
 		SecurityContext: controller.PrivilegedContext(true),
 		Resources:       osdProps.resources,
@@ -1195,7 +1195,7 @@ func (c *Cluster) getEncryptedStatusPVCInitContainer(mountPath string, osdProps 
 		Command: []string{
 			"cryptsetup",
 		},
-		Args:            []string{"--verbose", "status", encryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
+		Args:            []string{"--verbose", "status", EncryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
 		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, osdProps.pvc.ClaimName)},
 		SecurityContext: controller.PrivilegedContext(true),
 		Resources:       osdProps.resources,

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -45,6 +45,7 @@ type Executor interface {
 	ExecuteCommandWithOutput(command string, arg ...string) (string, error)
 	ExecuteCommandWithCombinedOutput(command string, arg ...string) (string, error)
 	ExecuteCommandWithTimeout(timeout time.Duration, command string, arg ...string) (string, error)
+	ExecuteCommandWithStdin(timeout time.Duration, command string, stdin *string, arg ...string) error
 }
 
 // CommandExecutor is the type of the Executor
@@ -53,6 +54,14 @@ type CommandExecutor struct{}
 // ExecuteCommand starts a process and wait for its completion
 func (c *CommandExecutor) ExecuteCommand(command string, arg ...string) error {
 	return c.ExecuteCommandWithEnv([]string{}, command, arg...)
+}
+
+// ExecuteCommandWithStdin starts a process, provides stdin and wait for its completion  with timeout.
+func (c *CommandExecutor) ExecuteCommandWithStdin(timeout time.Duration, command string, stdin *string, arg ...string) error {
+	output, err := executeCommandWithTimeout(timeout, command, stdin, arg...)
+	logger.Infof("Command %q output: %q", command, output)
+
+	return err
 }
 
 // ExecuteCommandWithEnv starts a process with env variables and wait for its completion
@@ -73,6 +82,11 @@ func (*CommandExecutor) ExecuteCommandWithEnv(env []string, command string, arg 
 
 // ExecuteCommandWithTimeout starts a process and wait for its completion with timeout.
 func (*CommandExecutor) ExecuteCommandWithTimeout(timeout time.Duration, command string, arg ...string) (string, error) {
+	return executeCommandWithTimeout(timeout, command, nil, arg...)
+}
+
+// executeCommandWithTimeout starts a process, provides stdin and wait for its completion with timeout.
+func executeCommandWithTimeout(timeout time.Duration, command string, stdin *string, arg ...string) (string, error) {
 	logCommand(command, arg...)
 	//nolint:gosec // Rook controls the input to the exec arguments
 	cmd := exec.Command(command, arg...)
@@ -80,6 +94,10 @@ func (*CommandExecutor) ExecuteCommandWithTimeout(timeout time.Duration, command
 	var b bytes.Buffer
 	cmd.Stdout = &b
 	cmd.Stderr = &b
+
+	if stdin != nil {
+		cmd.Stdin = strings.NewReader(*stdin)
+	}
 
 	if err := cmd.Start(); err != nil {
 		return "", err

--- a/pkg/util/exec/exec_test.go
+++ b/pkg/util/exec/exec_test.go
@@ -19,6 +19,7 @@ package exec
 import (
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -106,6 +107,68 @@ func TestExtractExitCode(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("ExtractExitCode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteCommandWithTimeout(t *testing.T) {
+	type args struct {
+		timeout time.Duration
+		command string
+		stdin   *string
+		arg     []string
+	}
+	testString := "hello"
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "test stdin",
+			args: args{
+				timeout: 30 * time.Second,
+				command: "cat",
+				stdin:   &testString,
+				arg:     []string{},
+			},
+			want:    testString,
+			wantErr: false,
+		},
+		{
+			name: "test nil stdin",
+			args: args{
+				timeout: 30 * time.Second,
+				command: "echo",
+				stdin:   nil,
+				arg:     []string{testString},
+			},
+			want:    testString,
+			wantErr: false,
+		},
+		{
+			name: "test timeout",
+			args: args{
+				timeout: 0 * time.Second,
+				command: "cat",
+				stdin:   &testString,
+				arg:     []string{},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := executeCommandWithTimeout(tt.args.timeout, tt.args.command, tt.args.stdin, tt.args.arg...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("executeCommandWithTimeout() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("executeCommandWithTimeout() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/util/exec/test/mockexec.go
+++ b/pkg/util/exec/test/mockexec.go
@@ -33,12 +33,22 @@ type MockExecutor struct {
 	MockExecuteCommandWithOutput         func(command string, arg ...string) (string, error)
 	MockExecuteCommandWithCombinedOutput func(command string, arg ...string) (string, error)
 	MockExecuteCommandWithTimeout        func(timeout time.Duration, command string, arg ...string) (string, error)
+	MockExecuteCommandWithStdin          func(timeout time.Duration, command string, stdin *string, arg ...string) error
 }
 
 // ExecuteCommand mocks ExecuteCommand
 func (e *MockExecutor) ExecuteCommand(command string, arg ...string) error {
 	if e.MockExecuteCommand != nil {
 		return e.MockExecuteCommand(command, arg...)
+	}
+
+	return nil
+}
+
+// ExecuteCommandWithStdin starts a process, provides stdin and wait for its completion with timeout.
+func (e *MockExecutor) ExecuteCommandWithStdin(timeout time.Duration, command string, stdin *string, arg ...string) error {
+	if e.MockExecuteCommand != nil {
+		return e.MockExecuteCommandWithStdin(timeout, command, stdin, arg...)
 	}
 
 	return nil

--- a/pkg/util/exec/translate_exec.go
+++ b/pkg/util/exec/translate_exec.go
@@ -38,6 +38,12 @@ func (e *TranslateCommandExecutor) ExecuteCommand(command string, arg ...string)
 	return e.Executor.ExecuteCommand(transCommand, transArgs...)
 }
 
+// ExecuteCommandWithStdin starts a process, provides stdin and wait for its completion with timeout.
+func (e *TranslateCommandExecutor) ExecuteCommandWithStdin(timeout time.Duration, command string, stdin *string, arg ...string) error {
+	transCommand, transArgs := e.Translator(command, arg...)
+	return e.Executor.ExecuteCommandWithStdin(timeout, transCommand, stdin, transArgs...)
+}
+
 // ExecuteCommandWithEnv starts a process with an env variable and wait for its completion
 func (e *TranslateCommandExecutor) ExecuteCommandWithEnv(env []string, command string, arg ...string) error {
 	transCommand, transArgs := e.Translator(command, arg...)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

[osd: re-open encrypted disk during osd-prepare-job if closed](https://github.com/red-hat-storage/rook/commit/f4e3838f812b429a71fd5b789ff48e1cde2aeccb) 

This commit implements this corner case during osd-prepare job.
```
The encrypted block is not opened, this is an extreme corner case
The OSD deployment has been removed manually AND the node rebooted
So we need to re-open the block to re-hydrate the OSDInfo.

Handling this case would mean, writing the encryption key on a
temporary file, then call luksOpen to open the encrypted block and
then call ceph-volume to list against the opened encrypted block.
We don't implement this, yet and return an error.
```
When underlying PVC for osd are CSI provisioned, the encrypted device
is closed when PVC is unmounted due to osd pod being deleted.
Therefore, this may occur more frequently and needs to be handled.
This commit implements the fix for the same.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit https://github.com/red-hat-storage/rook/commit/bde286ef495fa456513f73ccd2e20b48b8f9d380)

[osd: remove stale dm device during osd-prepare-job](https://github.com/red-hat-storage/rook/commit/00bc24b95f94f709bccd0c5ac0b4036393e60d4e) 

During osd-prepare-job,

The encrypted device is found to be closed in some cases when
the OSD deployment has been removed manually accompanied
by any of following cases:
- node reboot
- csi managed PVC being unmounted etc

while re-opening the block to re-hydrate the OSDInfo,
the dm device `<pvc-name>-block-dmcrypt` clashes with
the one used by OSD pod which is stale by now.
This commit adds cmd to remove this stale dm device.
Error with output "No such device" is ignored.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit https://github.com/red-hat-storage/rook/commit/24fa9ed935b3287acaf2867c58d015f5addd1b43)

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
