### PR TITLE
Bug 2144067: core: Read mon secret from file instead of env var

### DIFF
--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -14,7 +14,7 @@ runs:
         go-version: 1.18
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.7.0
+      uses: manusa/actions-setup-minikube@v2.7.2
       with:
         minikube version: "v1.26.1"
         kubernetes version: "v1.23.0"

--- a/.github/workflows/integration-test-config-latest-k8s/action.yaml
+++ b/.github/workflows/integration-test-config-latest-k8s/action.yaml
@@ -17,7 +17,7 @@ runs:
         go-version: 1.18
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.7.0
+      uses: manusa/actions-setup-minikube@v2.7.2
       with:
         minikube version: "v1.26.1"
         kubernetes version: ${{ inputs.kubernetes-version }}

--- a/cmd/rook/ceph/ceph.go
+++ b/cmd/rook/ceph/ceph.go
@@ -73,7 +73,6 @@ func addCephFlags(command *cobra.Command) {
 	command.Flags().StringVar(&clusterInfo.FSID, "fsid", "", "the cluster uuid")
 	command.Flags().StringVar(&clusterInfo.MonitorSecret, "mon-secret", "", "the cephx keyring for monitors")
 	command.Flags().StringVar(&clusterInfo.CephCred.Username, "ceph-username", "", "ceph username")
-	command.Flags().StringVar(&clusterInfo.CephCred.Secret, "ceph-secret", "", "secret for the ceph user (random if not specified)")
 	command.Flags().StringVar(&cfg.monEndpoints, "mon-endpoints", "", "ceph mon endpoints")
 	command.Flags().StringVar(&cfg.dataDir, "config-dir", "/var/lib/rook", "directory for storing configuration")
 	command.Flags().StringVar(&cfg.cephConfigOverride, "ceph-config-override", "", "optional path to a ceph config file that will be appended to the config files that rook generates")

--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ceph
 
 import (
+	"path"
 	"time"
 
 	"github.com/rook/rook/cmd/rook/rook"
@@ -67,6 +68,10 @@ func init() {
 func runMgrSidecar(cmd *cobra.Command, args []string) error {
 	rook.SetLogLevel()
 	clusterInfo.Context = cmd.Context()
+
+	if err := readCephSecret(path.Join(mon.CephSecretMountPath, mon.CephSecretFilename)); err != nil {
+		rook.TerminateFatal(err)
+	}
 
 	context := createContext()
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)

--- a/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -37,11 +37,6 @@ spec:
                 secretKeyRef:
                   name: rook-ceph-mon
                   key: ceph-username
-            - name: ROOK_CEPH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: rook-ceph-mon
-                  key: ceph-secret
 {{- if .Values.toolbox.resources }}
           resources:
 {{- toYaml .Values.toolbox.resources | nindent 12 }}
@@ -51,7 +46,16 @@ spec:
               name: ceph-config
             - name: mon-endpoint-volume
               mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
       volumes:
+        - name: ceph-admin-secret
+          secret:
+            secretName: rook-ceph-mon
+            optional: false
+            items:
+            - key: ceph-secret
+              path: secret.keyring
         - name: mon-endpoint-volume
           configMap:
             name: rook-ceph-mon-endpoints

--- a/deploy/examples/direct-mount.yaml
+++ b/deploy/examples/direct-mount.yaml
@@ -29,11 +29,6 @@ spec:
                 secretKeyRef:
                   name: rook-ceph-mon
                   key: ceph-username
-            - name: ROOK_CEPH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: rook-ceph-mon
-                  key: ceph-secret
           securityContext:
             privileged: true
             runAsUser: 0
@@ -46,9 +41,18 @@ spec:
               name: libmodules
             - name: mon-endpoint-volume
               mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
       # if hostNetwork: false, the "rbd map" command hangs, see https://github.com/rook/rook/issues/2021
       hostNetwork: true
       volumes:
+        - name: ceph-admin-secret
+          secret:
+            secretName: rook-ceph-mon
+            optional: false
+            items:
+              - key: ceph-secret
+                path: secret.keyring
         - name: dev
           hostPath:
             path: /dev

--- a/deploy/examples/osd-purge.yaml
+++ b/deploy/examples/osd-purge.yaml
@@ -60,11 +60,6 @@ spec:
                 secretKeyRef:
                   key: ceph-username
                   name: rook-ceph-mon
-            - name: ROOK_CEPH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: ceph-secret
-                  name: rook-ceph-mon
             - name: ROOK_CONFIG_DIR
               value: /var/lib/rook
             - name: ROOK_CEPH_CONFIG_OVERRIDE
@@ -81,7 +76,16 @@ spec:
               name: ceph-conf-emptydir
             - mountPath: /var/lib/rook
               name: rook-config
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
       volumes:
+        - name: ceph-admin-secret
+          secret:
+            secretName: rook-ceph-mon
+            optional: false
+            items:
+              - key: ceph-secret
+                path: secret.keyring
         - emptyDir: {}
           name: ceph-conf-emptydir
         - emptyDir: {}

--- a/deploy/examples/toolbox-job.yaml
+++ b/deploy/examples/toolbox-job.yaml
@@ -20,16 +20,13 @@ spec:
                 secretKeyRef:
                   name: rook-ceph-mon
                   key: ceph-username
-            - name: ROOK_CEPH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: rook-ceph-mon
-                  key: ceph-secret
           volumeMounts:
             - mountPath: /etc/ceph
               name: ceph-config
             - name: mon-endpoint-volume
               mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
       containers:
         - name: script
           image: rook/ceph:v1.10.2
@@ -47,6 +44,13 @@ spec:
               # example: print the ceph status
               ceph status
       volumes:
+        - name: ceph-admin-secret
+          secret:
+            secretName: rook-ceph-mon
+            optional: false
+            items:
+              - key: ceph-secret
+                path: secret.keyring
         - name: mon-endpoint-volume
           configMap:
             name: rook-ceph-mon-endpoints

--- a/deploy/examples/toolbox.yaml
+++ b/deploy/examples/toolbox.yaml
@@ -68,10 +68,16 @@ spec:
                 done
               }
 
+              # read the secret from an env var (for backward compatibility), or from the secret file
+              ceph_secret=${ROOK_CEPH_SECRET}
+              if [[ "$ceph_secret" == "" ]]; then
+                ceph_secret=$(cat /var/lib/rook-ceph-mon/secret.keyring)
+              fi
+
               # create the keyring file
               cat <<EOF > ${KEYRING_FILE}
               [${ROOK_CEPH_USERNAME}]
-              key = ${ROOK_CEPH_SECRET}
+              key = ${ceph_secret}
               EOF
 
               # write the initial config file
@@ -91,17 +97,22 @@ spec:
                 secretKeyRef:
                   name: rook-ceph-mon
                   key: ceph-username
-            - name: ROOK_CEPH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: rook-ceph-mon
-                  key: ceph-secret
           volumeMounts:
             - mountPath: /etc/ceph
               name: ceph-config
             - name: mon-endpoint-volume
               mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
+              readOnly: true
       volumes:
+        - name: ceph-admin-secret
+          secret:
+            secretName: rook-ceph-mon
+            optional: false
+            items:
+              - key: ceph-secret
+                path: secret.keyring
         - name: mon-endpoint-volume
           configMap:
             name: rook-ceph-mon-endpoints

--- a/design/ceph/ceph-nfs-ganesha.md
+++ b/design/ceph/ceph-nfs-ganesha.md
@@ -339,8 +339,6 @@ EXPORT {
 }
 ```
 
->>>>>>> 005000212 (nfs: add kerberos client security support)
-
 <!-- LINKS -->
 [NFS-Ganesha]: https://github.com/nfs-ganesha/nfs-ganesha/wiki
 [CephFS]: http://docs.ceph.com/docs/master/cephfs/nfs/

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -73,6 +73,7 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error)
 	if c.spec.Mgr.Count > 1 {
 		podSpec.Spec.Containers = append(podSpec.Spec.Containers, c.makeMgrSidecarContainer(mgrConfig))
 		matchLabels := controller.AppLabels(AppName, c.clusterInfo.Namespace)
+		podSpec.Spec.Volumes = append(podSpec.Spec.Volumes, mon.CephSecretVolume())
 
 		// Stretch the mgrs across hosts by default, or across a bigger failure domain for stretch clusters
 		topologyKey := v1.LabelHostname
@@ -212,7 +213,6 @@ func (c *Cluster) makeMgrSidecarContainer(mgrConfig *mgrConfig) v1.Container {
 		mon.PodNamespaceEnvVar(c.clusterInfo.Namespace),
 		mon.EndpointEnvVar(),
 		mon.CephUsernameEnvVar(),
-		mon.CephSecretEnvVar(),
 		k8sutil.ConfigOverrideEnvVar(),
 		{Name: "ROOK_DASHBOARD_ENABLED", Value: strconv.FormatBool(c.spec.Dashboard.Enabled)},
 		{Name: "ROOK_MONITORING_ENABLED", Value: strconv.FormatBool(c.spec.Monitoring.Enabled)},
@@ -228,6 +228,7 @@ func (c *Cluster) makeMgrSidecarContainer(mgrConfig *mgrConfig) v1.Container {
 		Env:             envVars,
 		Resources:       cephv1.GetMgrSidecarResources(c.spec.Resources),
 		SecurityContext: controller.PrivilegedContext(true),
+		VolumeMounts:    []v1.VolumeMount{mon.CephSecretVolumeMount()},
 	}
 }
 

--- a/pkg/operator/ceph/cluster/mon/env.go
+++ b/pkg/operator/ceph/cluster/mon/env.go
@@ -38,9 +38,3 @@ func CephUsernameEnvVar() v1.EnvVar {
 	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephUsernameKey}
 	return v1.EnvVar{Name: "ROOK_CEPH_USERNAME", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
 }
-
-// CephSecretEnvVar is the ceph secret environment var
-func CephSecretEnvVar() v1.EnvVar {
-	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephUserSecretKey}
-	return v1.EnvVar{Name: "ROOK_CEPH_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
-}

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -73,7 +73,6 @@ func (c *Cluster) getConfigEnvVars(osdProps osdProperties, dataDir string, prepa
 	if prepare {
 		envVars = append(envVars, []v1.EnvVar{
 			opmon.CephUsernameEnvVar(),
-			opmon.CephSecretEnvVar(),
 			{Name: "ROOK_FSID", ValueFrom: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
 					LocalObjectReference: v1.LocalObjectReference{Name: "rook-ceph-mon"},

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	kms "github.com/rook/rook/pkg/daemon/ceph/osd/kms"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -104,9 +105,12 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 
 	// create a volume on /dev so the pod can access devices on the host
 	devVolume := v1.Volume{Name: "devices", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/dev"}}}
-	volumes = append(volumes, devVolume)
 	udevVolume := v1.Volume{Name: "udev", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/run/udev"}}}
-	volumes = append(volumes, udevVolume)
+	volumes = append(volumes, []v1.Volume{
+		udevVolume,
+		devVolume,
+		mon.CephSecretVolume(),
+	}...)
 
 	if osdProps.onPVC() {
 		// Create volume config for PVCs
@@ -235,6 +239,7 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 		{Name: "devices", MountPath: "/dev"},
 		{Name: "udev", MountPath: "/run/udev"},
 		copyBinariesMount,
+		mon.CephSecretVolumeMount(),
 	}...)
 
 	// If the OSD runs on PVC


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Environment variables are not recommended for secrets in pods since they can be easily leaked if the environemnt variables are logged. By mounting the mon secret as a file, the mgr and osd prepare pods can read the mon secret from a file for better security.

This in addition to https://github.com/rook/rook/pull/11331 should mean rook is compliant with not using the secrets.

The one exception to this is that the CSI driver and many of the Ceph pods mount the rook-ceph-config secret, but it does not contain confidential information. The secret only contains the mon endpoints, which is necessary to save as a secret for the csi driver.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=2144067

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
