### PR TITLE
Bug 2154163: operator: disable webhook by default

### DIFF
--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -563,6 +563,9 @@ spec:
               name: https-webhook
               protocol: TCP
           env:
+            - name: ROOK_DISABLE_ADMISSION_CONTROLLER
+              value: "false"
+
             - name: ROOK_CURRENT_NAMESPACE_ONLY
               value: "false"
             # Rook Discover toleration. Will tolerate all taints with all keys.

--- a/pkg/operator/ceph/controller.go
+++ b/pkg/operator/ceph/controller.go
@@ -18,6 +18,7 @@ package operator
 
 import (
 	"context"
+	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -79,14 +80,14 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 	if err != nil {
 		return err
 	}
-
-	// Watch for Secret (admission controller secret)
-	err = c.Watch(&source.Kind{
-		Type: &v1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: v1.SchemeGroupVersion.String()}}}, &handler.EnqueueRequestForObject{}, predicateController(ctx, mgr.GetClient()))
-	if err != nil {
-		return err
+	if os.Getenv(webhookEnv) == "false" {
+		// Watch for Secret (admission controller secret)
+		err = c.Watch(&source.Kind{
+			Type: &v1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: v1.SchemeGroupVersion.String()}}}, &handler.EnqueueRequestForObject{}, predicateController(ctx, mgr.GetClient()))
+		if err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
 

--- a/pkg/operator/ceph/webhook-config.go
+++ b/pkg/operator/ceph/webhook-config.go
@@ -257,14 +257,26 @@ func webhookRules(name, resource, resourceServicePath string) admv1.ValidatingWe
 // No need to return err here since we are just deleting and not handle errors
 func deleteWebhookResources(ctx context.Context, certMgrClient *cs.CertmanagerV1Client, clusterdContext *clusterd.Context) {
 	logger.Infof("deleting validating webhook %s", webhookConfigName)
-	_ = clusterdContext.Clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, webhookConfigName, metav1.DeleteOptions{})
+	err := clusterdContext.Clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, webhookConfigName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Errorf("failed to delete validating webhook %s. %v", webhookConfigName, err)
+	}
 
 	logger.Infof("deleting webhook cert manager Certificate %s", certificateName)
-	_ = certMgrClient.Certificates(namespace).Delete(ctx, certificateName, metav1.DeleteOptions{})
+	err = certMgrClient.Certificates(namespace).Delete(ctx, certificateName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Errorf("failed to delete webhook cert manager Certificate %s. %v", certificateName, err)
+	}
 
 	logger.Info("deleting webhook cert manager Issuer %s", issuerName)
-	_ = certMgrClient.Issuers(namespace).Delete(ctx, issuerName, metav1.DeleteOptions{})
+	err = certMgrClient.Issuers(namespace).Delete(ctx, issuerName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Errorf("failed to delete webhook cert manager Issuer %s. %v", issuerName, err)
+	}
 
 	logger.Info("deleting validating webhook service %s", admissionControllerAppName)
-	_ = clusterdContext.Clientset.CoreV1().Services(namespace).Delete(ctx, admissionControllerAppName, metav1.DeleteOptions{})
+	err = clusterdContext.Clientset.CoreV1().Services(namespace).Delete(ctx, admissionControllerAppName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Errorf("failed to delete validating webhook service %s. %v", admissionControllerAppName, err)
+	}
 }

--- a/pkg/operator/ceph/webhook-config.go
+++ b/pkg/operator/ceph/webhook-config.go
@@ -28,7 +28,6 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	admv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -255,23 +254,17 @@ func webhookRules(name, resource, resourceServicePath string) admv1.ValidatingWe
 	}
 }
 
-func deleteIssuerAndCetificate(ctx context.Context, certMgrClient *cs.CertmanagerV1Client, clusterdContext *clusterd.Context) error {
+// No need to return err here since we are just deleting and not handle errors
+func deleteWebhookResources(ctx context.Context, certMgrClient *cs.CertmanagerV1Client, clusterdContext *clusterd.Context) {
+	logger.Infof("deleting validating webhook %s", webhookConfigName)
+	_ = clusterdContext.Clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, webhookConfigName, metav1.DeleteOptions{})
 
-	err := clusterdContext.Clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, webhookConfigName, metav1.DeleteOptions{})
-	if err != nil && !kerrors.IsNotFound(err) {
-		logger.Errorf("failed to delete validating webhook %s. %v", webhookConfigName, err)
-		return err
-	}
-	err = certMgrClient.Certificates(namespace).Delete(ctx, certificateName, metav1.DeleteOptions{})
-	if err != nil && !kerrors.IsNotFound(err) {
-		logger.Errorf("failed to delete issuer %s. %v", issuerName, err)
-		return err
-	}
+	logger.Infof("deleting webhook cert manager Certificate %s", certificateName)
+	_ = certMgrClient.Certificates(namespace).Delete(ctx, certificateName, metav1.DeleteOptions{})
 
-	err = certMgrClient.Issuers(namespace).Delete(ctx, issuerName, metav1.DeleteOptions{})
-	if err != nil && !kerrors.IsNotFound(err) {
-		logger.Errorf("failed to delete certificate %s. %v", certificateName, err)
-		return err
-	}
-	return nil
+	logger.Info("deleting webhook cert manager Issuer %s", issuerName)
+	_ = certMgrClient.Issuers(namespace).Delete(ctx, issuerName, metav1.DeleteOptions{})
+
+	logger.Info("deleting validating webhook service %s", admissionControllerAppName)
+	_ = clusterdContext.Clientset.CoreV1().Services(namespace).Delete(ctx, admissionControllerAppName, metav1.DeleteOptions{})
 }

--- a/pkg/operator/ceph/webhook.go
+++ b/pkg/operator/ceph/webhook.go
@@ -52,10 +52,9 @@ func createWebhook(ctx context.Context, context *clusterd.Context) (bool, error)
 	}
 
 	if os.Getenv(webhookEnv) == "true" {
-		logger.Info("delete Issuer and Certificate since secret is not found")
-		if err = deleteIssuerAndCetificate(ctx, certMgrClient, context); err != nil {
-			logger.Errorf("failed to delete issuer or certificate. %v", err)
-		}
+		logger.Info("delete webhook resources since webhook is disabled")
+
+		deleteWebhookResources(ctx, certMgrClient, context)
 		return false, nil
 	}
 
@@ -84,9 +83,8 @@ func createWebhook(ctx context.Context, context *clusterd.Context) (bool, error)
 		if apierrors.IsNotFound(err) {
 			// If secret is not found. All good ! Proceed with rook without admission controllers
 			logger.Info("delete Issuer and Certificate since secret is not found")
-			if err = deleteIssuerAndCetificate(ctx, certMgrClient, context); err != nil {
-				logger.Infof("could not delete issuer or certificate. %v", err)
-			}
+			deleteWebhookResources(ctx, certMgrClient, context)
+
 			logger.Infof("admission webhook secret %q not found. proceeding without the admission controller", admissionControllerAppName)
 			return false, nil
 		}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
operator: disable webhook by default

disable webhook in the downstream cluster.

operator: adding logs for debugging
adding more logs for debugging

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
