### PR TITLE
Bug 2167304: security: run the crash collector as ceph user

### DIFF
--- a/.docs/macros/includes/main.py
+++ b/.docs/macros/includes/main.py
@@ -12,7 +12,6 @@ subst = "\\1/%s/"
 
 
 def define_env(env):
-
     repo = Repository(".")
     if repo is not None:
         target = repo.head.shorthand

--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -258,11 +258,13 @@ func getCrashDaemonContainer(cephCluster cephv1.CephCluster, cephVersion cephver
 		Command: []string{
 			"ceph-crash",
 		},
-		Image:           cephImage,
-		Env:             envVars,
-		VolumeMounts:    volumeMounts,
-		Resources:       cephv1.GetCrashCollectorResources(cephCluster.Spec.Resources),
-		SecurityContext: controller.PodSecurityContext(),
+		Image:        cephImage,
+		Env:          envVars,
+		VolumeMounts: volumeMounts,
+		Resources:    cephv1.GetCrashCollectorResources(cephCluster.Spec.Resources),
+		// Initialize the security context with the ceph user since the ceph-crash script does not have an argument
+		// to run as the ceph user
+		SecurityContext: controller.CephSecurityContext(),
 	}
 
 	return container

--- a/pkg/operator/ceph/cluster/crash/crash_test.go
+++ b/pkg/operator/ceph/cluster/crash/crash_test.go
@@ -25,6 +25,7 @@ import (
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/test"
@@ -151,6 +152,8 @@ func TestCreateOrUpdateCephCrash(t *testing.T) {
 	assert.Equal(t, tolerations, podSpec.Spec.Tolerations)
 	assert.Equal(t, false, podSpec.Spec.HostNetwork)
 	assert.Equal(t, "", podSpec.Spec.PriorityClassName)
+	assert.Equal(t, int64(controller.CephUserID), *podSpec.Spec.Containers[0].SecurityContext.RunAsUser)
+	assert.Equal(t, int64(controller.CephUserID), *podSpec.Spec.Containers[0].SecurityContext.RunAsGroup)
 
 	cephCluster.Spec.Labels[cephv1.KeyCrashCollector] = map[string]string{"foo": "bar"}
 	cephCluster.Spec.Network.HostNetwork = true

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -38,6 +38,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -53,6 +54,7 @@ const (
 	daemonTypeLabel                         = "ceph_daemon_type"
 	ExternalMgrAppName                      = "rook-ceph-mgr-external"
 	ServiceExternalMetricName               = "http-external-metrics"
+	CephUserID                              = 167
 	livenessProbeTimeoutSeconds       int32 = 5
 	livenessProbeInitialDelaySeconds  int32 = 10
 	startupProbeFailuresDaemonDefault int32 = 6 // multiply by 10 = effective startup timeout
@@ -650,6 +652,14 @@ func PodSecurityContext() *v1.SecurityContext {
 	return &v1.SecurityContext{
 		Privileged: &privileged,
 	}
+}
+
+// PodSecurityContext detects if the pod needs privileges to run
+func CephSecurityContext() *v1.SecurityContext {
+	context := PodSecurityContext()
+	context.RunAsUser = pointer.Int64(CephUserID)
+	context.RunAsGroup = pointer.Int64(CephUserID)
+	return context
 }
 
 // PrivilegedContext returns a privileged Pod security context


### PR DESCRIPTION
The crash collector does not have the command line arguments to run as ceph user id 167, so we set the security context to run as the ceph user in the main crash collector container.

Signed-off-by: Travis Nielsen <tnielsen@redhat.com>
(cherry picked from commit df6d7af355440eab3fae7eea970f9196b5de125f)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
