### PR TITLE
nfs: add support for nfs-ganesha metrics monitoring

### DIFF
--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -35,10 +35,11 @@ import (
 
 const (
 	// AppName is the name of the app
-	AppName             = "rook-ceph-nfs"
-	ganeshaConfigVolume = "ganesha-config"
-	nfsPort             = 2049
-	ganeshaPid          = "/var/run/ganesha/ganesha.pid"
+	AppName               = "rook-ceph-nfs"
+	ganeshaConfigVolume   = "ganesha-config"
+	nfsPort               = 2049
+	ganeshaPid            = "/var/run/ganesha/ganesha.pid"
+	nfsGaneshaMetricsPort = 9587
 )
 
 func (r *ReconcileCephNFS) generateCephNFSService(nfs *cephv1.CephNFS, cfg daemonConfig) *v1.Service {
@@ -57,6 +58,12 @@ func (r *ReconcileCephNFS) generateCephNFSService(nfs *cephv1.CephNFS, cfg daemo
 					Name:       "nfs",
 					Port:       nfsPort,
 					TargetPort: intstr.FromInt(int(nfsPort)),
+					Protocol:   v1.ProtocolTCP,
+				},
+				{
+					Name:       "nfs-metrics",
+					Port:       nfsGaneshaMetricsPort,
+					TargetPort: intstr.FromInt(int(nfsGaneshaMetricsPort)),
 					Protocol:   v1.ProtocolTCP,
 				},
 			},


### PR DESCRIPTION
NFS-Ganesha (as of V5-dev.2 [1]) supports Prometheus monitoring from within the NFS server itself. It provides metrics for both connected clients and active exports, via TCP port 9587. Expose those metrics via existing nfs k8s-service.

[1] https://github.com/nfs-ganesha/nfs-ganesha/commit/b6c59df5a0b8a3ae5b2a87446f8906cb321ee026

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
