### PR TITLE
Bug 2089137: external: fix import errors for python2

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -20,15 +20,19 @@ import json
 import argparse
 import re
 from tokenize import single_quoted
-import requests
 import subprocess
 import hmac
 from hashlib import sha1 as sha
 from os import linesep as LINESEP
 from os import path
-import urllib.parse
 from email.utils import formatdate
+import requests
 from requests.auth import AuthBase
+
+py3k = False
+if sys.version_info.major >= 3:
+    py3k = True
+    import urllib.parse
 
 ModuleNotFoundError = ImportError
 
@@ -58,15 +62,10 @@ except ModuleNotFoundError:
     # for 3.x
     from urllib.parse import urlparse
 
-py3k = False
 try:
-    from urlparse import urlparse, unquote
     from base64 import encodestring
 except:
-    py3k = True
-    from urllib.parse import urlparse, unquote
     from base64 import encodebytes as encodestring
-
 
 class ExecutionFailureException(Exception):
     pass


### PR DESCRIPTION
remove duplicate import urllib.parse which is handled below with try and except no need to import separately. Also, change the way to get the python version.


(cherry picked from commit 9a952df419f8d9273e695bff3557986f82e6e166)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
