### PR TITLE
Bug 2188381: external: add alias rbd pool name to support . pools name

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -374,6 +374,12 @@ class RadosJSON:
             help="Provides the name of the RBD datapool",
         )
         output_group.add_argument(
+            "--alias-rbd-data-pool-name",
+            default="",
+            required=False,
+            help="Provides an alias for the  RBD data pool name, necessary if a special character is present in the pool name such as a period or underscore",
+        )
+        output_group.add_argument(
             "--rgw-endpoint",
             default="",
             required=False,
@@ -816,6 +822,30 @@ class RadosJSON:
 
         return caps, entity
 
+    def get_entity(self, entity, rbd_pool_name, alias_rbd_pool_name, cluster_name):
+        if (
+            rbd_pool_name.count(".") != 0
+            or rbd_pool_name.count("_") != 0
+            or alias_rbd_pool_name != ""
+            # checking alias_rbd_pool_name is not empty as there maybe a special character used other than . or _
+        ):
+            if alias_rbd_pool_name == "":
+                raise ExecutionFailureException(
+                    "please set the '--alias-rbd-data-pool-name' flag as the rbd data pool name contains '.' or '_'"
+                )
+            if (
+                alias_rbd_pool_name.count(".") != 0
+                or alias_rbd_pool_name.count("_") != 0
+            ):
+                raise ExecutionFailureException(
+                    "'--alias-rbd-data-pool-name' flag value should not contain '.' or '_'"
+                )
+            entity = f"{entity}-{cluster_name}-{alias_rbd_pool_name}"
+        else:
+            entity = f"{entity}-{cluster_name}-{rbd_pool_name}"
+
+        return entity
+
     def get_rbd_provisioner_caps_and_entity(self):
         entity = "client.csi-rbd-provisioner"
         caps = {
@@ -825,15 +855,16 @@ class RadosJSON:
         }
         if self._arg_parser.restricted_auth_permission:
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
+            alias_rbd_pool_name = self._arg_parser.alias_rbd_data_pool_name
             cluster_name = self._arg_parser.cluster_name
             if rbd_pool_name == "" or cluster_name == "":
                 raise ExecutionFailureException(
                     "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' flags"
                 )
-            entity = "{}-{}-{}".format(
-                entity, cluster_name, rbd_pool_name
+            entity = self.get_entity(
+                entity, rbd_pool_name, alias_rbd_pool_name, cluster_name
             )
-            caps["osd"] = "profile rbd pool={}".format(rbd_pool_name)
+            caps["osd"] = f"profile rbd pool={rbd_pool_name}"
 
         return caps, entity
 
@@ -845,15 +876,16 @@ class RadosJSON:
         }
         if self._arg_parser.restricted_auth_permission:
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
+            alias_rbd_pool_name = self._arg_parser.alias_rbd_data_pool_name
             cluster_name = self._arg_parser.cluster_name
             if rbd_pool_name == "" or cluster_name == "":
                 raise ExecutionFailureException(
                     "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' flags"
                 )
-            entity = "{}-{}-{}".format(
-                entity, cluster_name, rbd_pool_name
+            entity = self.get_entity(
+                entity, rbd_pool_name, alias_rbd_pool_name, cluster_name
             )
-            caps["osd"] = "profile rbd pool={}".format(rbd_pool_name)
+            caps["osd"] = f"profile rbd pool={rbd_pool_name}"
 
         return caps, entity
 


### PR DESCRIPTION
if restricted permission was on the . was appended to k8s secret and failed to create the secret so added a alias name is user wan't to suuport pool with . in name


(cherry picked from commit 6c3dabcf5fe9fc131a736072da725727b9108914) (cherry picked from commit 44c44d637ec7dd0c3991210a82df8dd39ea42e46)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
