### PR TITLE
Bug 2177106: external: check for pool and cluster name is provided

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -857,9 +857,13 @@ class RadosJSON:
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
             alias_rbd_pool_name = self._arg_parser.alias_rbd_data_pool_name
             cluster_name = self._arg_parser.cluster_name
-            if rbd_pool_name == "" or cluster_name == "":
+            if rbd_pool_name == "":
                 raise ExecutionFailureException(
-                    "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' flags"
+                    "mandatory flag not found, please set the '--rbd-data-pool-name' flag"
+                )
+            if cluster_name == "":
+                raise ExecutionFailureException(
+                    "mandatory flag not found, please set the '--cluster-name' flag"
                 )
             entity = self.get_entity(
                 entity, rbd_pool_name, alias_rbd_pool_name, cluster_name
@@ -878,6 +882,14 @@ class RadosJSON:
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
             alias_rbd_pool_name = self._arg_parser.alias_rbd_data_pool_name
             cluster_name = self._arg_parser.cluster_name
+            if rbd_pool_name == "":
+                raise ExecutionFailureException(
+                    "mandatory flag not found, please set the '--rbd-data-pool-name' flag"
+                )
+            if cluster_name == "":
+                raise ExecutionFailureException(
+                    "mandatory flag not found, please set the '--cluster-name' flag"
+                )
             entity = self.get_entity(
                 entity, rbd_pool_name, alias_rbd_pool_name, cluster_name
             )


### PR DESCRIPTION
While adding the support for dot and special rbd pools the check for pool and cluster name check was removed, Adding it back as it is needed
https://github.com/rook/rook/pull/12056

Signed-off-by: parth-gr <paarora@redhat.com>
(cherry picked from commit f7f88be0821ea649064fc1b5e6988e65676dc876)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
