### PR TITLE
Bug: 2183266: core: skip OBC and Notification controllers

### DIFF
--- a/pkg/operator/ceph/object/bucket/controller.go
+++ b/pkg/operator/ceph/object/bucket/controller.go
@@ -18,6 +18,7 @@ package bucket
 
 import (
 	"context"
+	"os"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/ceph/object"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,6 +55,10 @@ type ReconcileBucket struct {
 // Add creates a new Ceph CSI Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, context *clusterd.Context, opManagerContext context.Context, opConfig opcontroller.OperatorConfig) error {
+	if os.Getenv(object.DisableOBCEnvVar) == "true" {
+		logger.Info("skip running Object Bucket controller")
+		return nil
+	}
 	return add(opManagerContext, mgr, newReconciler(mgr, context, opManagerContext, opConfig))
 }
 

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -53,6 +53,9 @@ import (
 
 const (
 	controllerName = "ceph-object-controller"
+	// DisableOBCEnvVar environment variable, if set to "true", will skip watching Object Bucket and Notification resources.
+	// This variable can be added to container spec of the `rook-ceph-operator` deployment.
+	DisableOBCEnvVar = "ROOK_DISABLE_OBJECT_BUCKET_CLAIM"
 )
 
 var waitForRequeueIfObjectStoreNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}

--- a/pkg/operator/ceph/object/notification/controller.go
+++ b/pkg/operator/ceph/object/notification/controller.go
@@ -19,6 +19,7 @@ package notification
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
@@ -28,6 +29,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/ceph/object/bucket"
 	"github.com/rook/rook/pkg/operator/ceph/object/topic"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
@@ -67,6 +69,11 @@ type ReconcileNotifications struct {
 // Add creates a new CephBucketNotification controller and a new ObjectBucketClaim Controller and adds it to the Manager.
 // The Manager will set fields on the Controller and start it when the Manager is started.
 func Add(mgr manager.Manager, context *clusterd.Context, opManagerContext context.Context, opConfig opcontroller.OperatorConfig) error {
+	if os.Getenv(object.DisableOBCEnvVar) == "true" {
+		logger.Info("skip running Object Bucket Notification controller")
+		return nil
+	}
+
 	if err := addNotificationReconciler(mgr, &ReconcileNotifications{
 		client:           mgr.GetClient(),
 		context:          context,


### PR DESCRIPTION
Skip running Object Bucket and Object bucket notification controllers based on env variable.

Signed-off-by: sp98 <sapillai@redhat.com>
(cherry picked from commit e87338fbc48ca564929feb5dc3097fdaf8f69e34) (cherry picked from commit 6cb4dab7d22ad5ecb5f164499e9b174d9248250b)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
