### PR TITLE
Bug 2192821: external: fixed validate_rgw_endpoint pool validation

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -1183,6 +1183,12 @@ class RadosJSON:
                     "info",
                     "--uid",
                     self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME,
+                    "--rgw-realm",
+                    self._arg_parser.rgw_realm_name,
+                    "--rgw-zonegroup",
+                    self._arg_parser.rgw_zonegroup_name,
+                    "--rgw-zone",
+                    self._arg_parser.rgw_zone_name,
                 ]
                 try:
                     output = subprocess.check_output(cmd, stderr=subprocess.PIPE)
@@ -1221,6 +1227,12 @@ class RadosJSON:
             self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME,
             "--caps",
             "info=read",
+            "--rgw-realm",
+            self._arg_parser.rgw_realm_name,
+            "--rgw-zonegroup",
+            self._arg_parser.rgw_zonegroup_name,
+            "--rgw-zone",
+            self._arg_parser.rgw_zone_name,
         ]
         try:
             output = subprocess.check_output(cmd, stderr=subprocess.PIPE)
@@ -1346,6 +1358,7 @@ class RadosJSON:
 
         # check if the rgw endpoint is reachable
         rgw_endpoint = self._arg_parser.rgw_endpoint
+        self._invalid_endpoint(rgw_endpoint)
         cert = None
         if not self._arg_parser.rgw_skip_tls and self.validate_rgw_endpoint_tls_cert():
             cert = self._arg_parser.rgw_tls_cert_path
@@ -1369,28 +1382,29 @@ class RadosJSON:
         # check if the rgw endpoint exist
         # only validate if rgw_pool_prefix is passed else it will take default value and we don't create these default pools
         if self._arg_parser.rgw_pool_prefix != "default":
-            rgw_pool_to_validate = [
+            rgw_pools_to_validate = [
                 f"{self._arg_parser.rgw_pool_prefix}.rgw.meta",
                 ".rgw.root",
                 f"{self._arg_parser.rgw_pool_prefix}.rgw.control",
                 f"{self._arg_parser.rgw_pool_prefix}.rgw.log",
             ]
-            if not self.cluster.pool_exists(rgw_pool_to_validate):
-                sys.stderr.write(
-                    f"The provided pool, '{rgw_pool_to_validate}', does not exist"
-                )
-                return "-1"
+            for _rgw_pool_to_validate in rgw_pools_to_validate:
+                if not self.cluster.pool_exists(_rgw_pool_to_validate):
+                    sys.stderr.write(
+                        f"The provided pool, '{_rgw_pool_to_validate}', does not exist"
+                    )
+                    return "-1"
 
         return ""
 
-    def validate_rgw_multisite(self, rgw_multisite_config, rgw_multisite_config_flag):
+    def validate_rgw_multisite(self, rgw_multisite_config_name, rgw_multisite_config):
         if rgw_multisite_config != "":
             cmd = [
                 "radosgw-admin",
-                "realm",
-                "get",
-                rgw_multisite_config_flag,
                 rgw_multisite_config,
+                "get",
+                "--rgw-" + rgw_multisite_config,
+                rgw_multisite_config_name,
             ]
             try:
                 _ = subprocess.check_output(cmd, stderr=subprocess.PIPE)
@@ -1470,27 +1484,41 @@ class RadosJSON:
             if self._arg_parser.dry_run:
                 self.create_rgw_admin_ops_user()
             else:
-                err = self.validate_rgw_multisite(
-                    self._arg_parser.rgw_realm_name, "--rgw-realm"
-                )
-                err = self.validate_rgw_multisite(
-                    self._arg_parser.rgw_zonegroup_name, "--rgw-zonegroup"
-                )
-                err = self.validate_rgw_multisite(
-                    self._arg_parser.rgw_zone_name, "--rgw-zone"
-                )
-                (
-                    self.out_map["RGW_ADMIN_OPS_USER_ACCESS_KEY"],
-                    self.out_map["RGW_ADMIN_OPS_USER_SECRET_KEY"],
-                    info_cap_supported,
-                    err,
-                ) = self.create_rgw_admin_ops_user()
-                err = self.validate_rgw_endpoint(info_cap_supported)
-                if self._arg_parser.rgw_tls_cert_path:
-                    self.out_map["RGW_TLS_CERT"] = self.validate_rgw_endpoint_tls_cert()
-                # if there is no error, set the RGW_ENDPOINT
-                if err != "-1":
-                    self.out_map["RGW_ENDPOINT"] = self._arg_parser.rgw_endpoint
+                if (
+                    self._arg_parser.rgw_realm_name == ""
+                    and self._arg_parser.rgw_zonegroup_name == ""
+                    and self._arg_parser.rgw_zone_name == ""
+                ) or (
+                    self._arg_parser.rgw_realm_name != ""
+                    and self._arg_parser.rgw_zonegroup_name != ""
+                    and self._arg_parser.rgw_zone_name != ""
+                ):
+                    err = self.validate_rgw_multisite(
+                        self._arg_parser.rgw_realm_name, "realm"
+                    )
+                    err = self.validate_rgw_multisite(
+                        self._arg_parser.rgw_zonegroup_name, "zonegroup"
+                    )
+                    err = self.validate_rgw_multisite(
+                        self._arg_parser.rgw_zone_name, "zone"
+                    )
+                    (
+                        self.out_map["RGW_ADMIN_OPS_USER_ACCESS_KEY"],
+                        self.out_map["RGW_ADMIN_OPS_USER_SECRET_KEY"],
+                        info_cap_supported,
+                        err,
+                    ) = self.create_rgw_admin_ops_user()
+                    err = self.validate_rgw_endpoint(info_cap_supported)
+                    if self._arg_parser.rgw_tls_cert_path:
+                        self.out_map[
+                            "RGW_TLS_CERT"
+                        ] = self.validate_rgw_endpoint_tls_cert()
+                    # if there is no error, set the RGW_ENDPOINT
+                    if err != "-1":
+                        self.out_map["RGW_ENDPOINT"] = self._arg_parser.rgw_endpoint
+                else:
+                    err = "Please provide all the RGW multisite parameters or none of them"
+                    sys.stderr.write(err)
 
     def gen_shell_out(self):
         self._gen_output_map()

--- a/pkg/operator/ceph/object/bucket/controller.go
+++ b/pkg/operator/ceph/object/bucket/controller.go
@@ -18,6 +18,7 @@ package bucket
 
 import (
 	"context"
+	"os"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/ceph/object"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,6 +55,10 @@ type ReconcileBucket struct {
 // Add creates a new Ceph CSI Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, context *clusterd.Context, opManagerContext context.Context, opConfig opcontroller.OperatorConfig) error {
+	if os.Getenv(object.DisableOBCEnvVar) == "true" {
+		logger.Info("skip running Object Bucket controller")
+		return nil
+	}
 	return add(opManagerContext, mgr, newReconciler(mgr, context, opManagerContext, opConfig))
 }
 

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -52,6 +52,9 @@ import (
 
 const (
 	controllerName = "ceph-object-controller"
+	// DisableOBCEnvVar environment variable, if set to "true", will skip watching Object Bucket and Notification resources.
+	// This variable can be added to container spec of the `rook-ceph-operator` deployment.
+	DisableOBCEnvVar = "ROOK_DISABLE_OBJECT_BUCKET_CLAIM"
 )
 
 var waitForRequeueIfObjectStoreNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}

--- a/pkg/operator/ceph/object/notification/controller.go
+++ b/pkg/operator/ceph/object/notification/controller.go
@@ -19,6 +19,7 @@ package notification
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
@@ -28,6 +29,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/ceph/object/bucket"
 	"github.com/rook/rook/pkg/operator/ceph/object/topic"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
@@ -67,6 +69,11 @@ type ReconcileNotifications struct {
 // Add creates a new CephBucketNotification controller and a new ObjectBucketClaim Controller and adds it to the Manager.
 // The Manager will set fields on the Controller and start it when the Manager is started.
 func Add(mgr manager.Manager, context *clusterd.Context, opManagerContext context.Context, opConfig opcontroller.OperatorConfig) error {
+	if os.Getenv(object.DisableOBCEnvVar) == "true" {
+		logger.Info("skip running Object Bucket Notification controller")
+		return nil
+	}
+
 	if err := addNotificationReconciler(mgr, &ReconcileNotifications{
 		client:           mgr.GetClient(),
 		context:          context,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
1) external: fixed validate_rgw_endpoint pool validation

The function pool_exists seems to only accept a string, but not a List, as it is given in validate_rgw_endpoint.
The change iterates calling pool_exists one by one over the list of pools given in validate_rgw_endpoint. This change made it possible to us to connect our RGW to OCP via Rook.

2) Add missing usage of realm, zone and zonegroup while retrieving user info and adding user capabilities.

Signed-off-by: Sergio Pérez Fernández <sergioperez794@gmail.com>
(cherry picked from commit a1e604ddd22c15282ea5bdef2f9fff5b3fb781bb)

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
