### PR TITLE
Bug 2227161: core: force delete rook-ceph-exporter pod

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -323,6 +323,7 @@ func (c *cephStatusChecker) getRookPodsOnNode(node string) ([]v1.Pod, error) {
 		"rook-ceph-mgr",
 		"rook-ceph-mds",
 		"rook-ceph-rgw",
+		"rook-ceph-exporter",
 	}
 	podsOnNode := []v1.Pod{}
 	listOpts := metav1.ListOptions{

--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -335,6 +335,7 @@ func TestGetRookPodsOnNode(t *testing.T) {
 		{"app": "rook-ceph-rgw"},
 		{"app": "user-app"},
 		{"app": "rook-ceph-mon"},
+		{"app": "rook-ceph-exporter"},
 	}
 
 	pod := v1.Pod{
@@ -362,7 +363,7 @@ func TestGetRookPodsOnNode(t *testing.T) {
 	pods, err := c.getRookPodsOnNode("node0")
 	assert.NoError(t, err)
 	// A pod is having two matching labels and its returned only once
-	assert.Equal(t, 11, len(pods))
+	assert.Equal(t, 12, len(pods))
 
 	podNames := []string{}
 	for _, pod := range pods {


### PR DESCRIPTION
Force delete rook-ceph-exporter pod that is stuck in terminating state due to unavailability of node.

Signed-off-by: sp98 <sapillai@redhat.com>
(cherry picked from commit dd90ef5db24bdea0654ebf04fbf6044ab070fd78)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
