### PR TITLE
Bug 2229646: external: fqdn should be persisted

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -135,6 +135,7 @@ gateway:
   port: 80
   externalRgwEndpoints:
     - ip: 192.168.39.182
+      # hostname: example.com
 ```
 
 This will create a service with the endpoint `192.168.39.182` on port `80`, pointing to the Ceph object external gateway.

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
@@ -80,6 +80,7 @@ spec:
     port: 8080
     externalRgwEndpoints:
       - ip: 192.168.39.182
+        # hostname: example.com
 ```
 
 You can use the existing `object-external.yaml` file.

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -11961,10 +11961,10 @@ spec:
                         description: EndpointAddress is a tuple that describes a single IP address or host name. This is a subset of Kubernetes's v1.EndpointAddress.
                         properties:
                           hostname:
-                            description: The Hostname of this endpoint
+                            description: The DNS-addressable Hostname of this endpoint. This field will be preferred over IP if both are given.
                             type: string
                           ip:
-                            description: The IP of this endpoint.
+                            description: The IP of this endpoint. As a legacy behavior, this supports being given a DNS-adressable hostname as well.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -11953,10 +11953,10 @@ spec:
                         description: EndpointAddress is a tuple that describes a single IP address or host name. This is a subset of Kubernetes's v1.EndpointAddress.
                         properties:
                           hostname:
-                            description: The Hostname of this endpoint
+                            description: The DNS-addressable Hostname of this endpoint. This field will be preferred over IP if both are given.
                             type: string
                           ip:
-                            description: The IP of this endpoint.
+                            description: The IP of this endpoint. As a legacy behavior, this supports being given a DNS-adressable hostname as well.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic

--- a/deploy/examples/create-external-cluster-resources-tests.py
+++ b/deploy/examples/create-external-cluster-resources-tests.py
@@ -187,15 +187,6 @@ class TestRadosJSON(unittest.TestCase):
         except ext.ExecutionFailureException as err:
             print(f"Successfully thrown error: {err}")
 
-    def test_convert_fqdn_rgw_endpoint_to_ip(self):
-        try:
-            rgw_endpoint_ip = self.rjObj.convert_fqdn_rgw_endpoint_to_ip(
-                "www.redhat.com:80"
-            )
-            print(f"Successfully Converted www.redhat.com to it's IP {rgw_endpoint_ip}")
-        except ext.ExecutionFailureException as err:
-            print(f"Successfully thrown error: {err}")
-
     def test_upgrade_user_permissions(self):
         self.rjObj = ext.RadosJSON(
             [

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -1225,19 +1225,6 @@ class RadosJSON:
             "",
         )
 
-    def convert_fqdn_rgw_endpoint_to_ip(self, fqdn_rgw_endpoint):
-        try:
-            fqdn, port = fqdn_rgw_endpoint.split(":")
-        except ValueError:
-            raise ExecutionFailureException(
-                f"Not a proper endpoint: {fqdn_rgw_endpoint}, "
-                "<FQDN>:<PORT>, format is expected"
-            )
-        rgw_endpoint_ip = self._convert_hostname_to_ip(fqdn)
-        rgw_endpoint_port = port
-        rgw_endpoint = self._join_host_port(rgw_endpoint_ip, rgw_endpoint_port)
-        return rgw_endpoint
-
     def validate_rbd_pool(self):
         if not self.cluster.pool_exists(self._arg_parser.rbd_data_pool_name):
             raise ExecutionFailureException(
@@ -1321,7 +1308,6 @@ class RadosJSON:
 
         # check if the rgw endpoint is reachable
         rgw_endpoint = self._arg_parser.rgw_endpoint
-        self._invalid_endpoint(rgw_endpoint)
         cert = None
         if not self._arg_parser.rgw_skip_tls and self.validate_rgw_endpoint_tls_cert():
             cert = self._arg_parser.rgw_tls_cert_path
@@ -1386,10 +1372,6 @@ class RadosJSON:
         self._arg_parser.cluster_name = (
             self._arg_parser.cluster_name.lower()
         )  # always convert cluster name to lowercase characters
-        if self._arg_parser.rgw_endpoint:
-            self._arg_parser.rgw_endpoint = self.convert_fqdn_rgw_endpoint_to_ip(
-                self._arg_parser.rgw_endpoint
-            )
         self.validate_rbd_pool()
         self.validate_rados_namespace()
         self.validate_subvolume_group()

--- a/deploy/examples/object-external.yaml
+++ b/deploy/examples/object-external.yaml
@@ -16,3 +16,4 @@ spec:
     port: 80
     externalRgwEndpoints:
       - ip: 192.168.39.182
+        # hostname: example.com

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1469,10 +1469,11 @@ type GatewaySpec struct {
 // Kubernetes's v1.EndpointAddress.
 // +structType=atomic
 type EndpointAddress struct {
-	// The IP of this endpoint.
+	// The IP of this endpoint. As a legacy behavior, this supports being given a DNS-adressable hostname as well.
 	// +optional
 	IP string `json:"ip" protobuf:"bytes,1,opt,name=ip"`
-	// The Hostname of this endpoint
+
+	// The DNS-addressable Hostname of this endpoint. This field will be preferred over IP if both are given.
 	// +optional
 	Hostname string `json:"hostname,omitempty" protobuf:"bytes,3,opt,name=hostname"`
 }


### PR DESCRIPTION
1) donot change rgw fqdn to ip if provided,
As now the bucket class supports the
entry of fqdn

2) update crds with new description in EndpointAddress


(cherry picked from commit f66de7b9df94bdf02b6d38b1a9cb1e4e63fdda81)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
