### PR TITLE
Bug 2237861: Disable exporter 4.13

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -50,7 +50,8 @@ const (
 )
 
 var (
-	MinVersionForCephExporter = cephver.CephVersion{Major: 17, Minor: 2, Extra: 6}
+	// expoter service isn't required in 4.13 which is based on 17.2.x
+	MinVersionForCephExporter = cephver.CephVersion{Major: 18, Minor: 0, Extra: 0}
 )
 
 // createOrUpdateCephExporter is a wrapper around controllerutil.CreateOrUpdate

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
@@ -44,7 +44,7 @@ func TestCreateOrUpdateCephExporter(t *testing.T) {
 	}
 	cephCluster.Spec.Labels = cephv1.LabelsSpec{}
 	cephCluster.Spec.PriorityClassNames = cephv1.PriorityClassNamesSpec{}
-	cephVersion := &cephver.CephVersion{Major: 17, Minor: 2, Extra: 6}
+	cephVersion := &cephver.CephVersion{Major: 18, Minor: 0, Extra: 0}
 	ctx := context.TODO()
 	context := &clusterd.Context{
 		Clientset:     test.New(t, 1),

--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -85,6 +85,18 @@ func (r *ReconcileNode) Reconcile(context context.Context, request reconcile.Req
 	return result, err
 }
 
+func (r *ReconcileNode) cleanupExporterResources(clusterNamespace string, ns string, nodeName string) (reconcile.Result, error) {
+	err := k8sutil.DeleteServiceMonitor(r.opManagerContext, ns, cephExporterAppName)
+	if err != nil {
+		logger.Debugf("failed to delete service monitor for ceph exporter in namespace %q on node %q", ns, nodeName)
+	}
+	err = k8sutil.DeleteService(r.opManagerContext, r.context.Clientset, r.opConfig.OperatorNamespace, cephExporterAppName)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "failed to delete ceph exporter metrics service in namespace %q on node %q", ns, nodeName)
+	}
+	return reconcile.Result{}, nil
+}
+
 func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, error) {
 	logger.Debugf("reconciling node: %q", request.Name)
 
@@ -195,6 +207,24 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 			if err != nil {
 				return reconcile.Result{}, errors.Wrapf(err, "failed to list and delete deployments in namespace %q on node %q", namespace, request.Name)
 			}
+			result, err := r.cleanupExporterResources(cephCluster.Namespace, namespace, request.Name)
+			if err != nil {
+				return result, errors.Wrapf(err, "failed to cleanup exporter resources in namespace %q on node %q", namespace, request.Name)
+			}
+		}
+		// Cleanup exporter if the ceph version isn't supported
+		if !cephVersion.IsAtLeast(MinVersionForCephExporter) {
+			for _, cephPod := range cephPods {
+				if cephPod.Spec.NodeName == request.Name {
+					if err := r.listDeploymentAndDelete(cephExporterAppName, request.Name, namespace); err != nil {
+						return reconcile.Result{}, errors.Wrap(err, "failed to delete ceph-exporter")
+					}
+					result, err := r.cleanupExporterResources(cephCluster.Namespace, namespace, request.Name)
+					if err != nil {
+						return result, errors.Wrapf(err, "failed to cleanup exporter resources in namespace %q on node %q", namespace, request.Name)
+					}
+				}
+			}
 		}
 
 		if err := r.reconcileCrashPruner(namespace, cephCluster, cephVersion); err != nil {
@@ -218,7 +248,7 @@ func (r *ReconcileNode) createOrUpdateNodeDaemons(node corev1.Node, tolerations 
 			logger.Debugf("crash collector successfully reconciled for node %q. operation: %q", node.Name, op)
 		}
 	}
-	if cephCluster.Spec.Monitoring.Enabled {
+	if cephVersion.IsAtLeast(MinVersionForCephExporter) && !cephCluster.Spec.Monitoring.Enabled {
 		op, err := r.createOrUpdateCephExporter(node, tolerations, cephCluster, cephVersion)
 		if err != nil {
 			if op == "unchanged" {

--- a/pkg/operator/k8sutil/prometheus.go
+++ b/pkg/operator/k8sutil/prometheus.go
@@ -26,6 +26,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	kerror "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sYAML "k8s.io/apimachinery/pkg/util/yaml"
@@ -85,4 +86,19 @@ func CreateOrUpdateServiceMonitor(ctx context.Context, serviceMonitorDefinition 
 		return nil, fmt.Errorf("failed to update servicemonitor. %v", err)
 	}
 	return sm, nil
+}
+
+// DeleteServiceMonitor deletes a ServiceMonitor and returns the error if any
+func DeleteServiceMonitor(ctx context.Context, ns string, name string) error {
+	client, err := getMonitoringClient()
+	if err != nil {
+		return fmt.Errorf("failed to get monitoring client. %v", err)
+	}
+	err = client.MonitoringV1().ServiceMonitors(ns).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if kerror.IsNotFound(err) {
+			return nil
+		}
+	}
+	return err
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The crashing of exporter daemons during upgrade from 4.13->4.14 is because in 4.13 we don't have fix required (Ceph upstream fix) which was recelty delivered to 4.14. Thus disabling exporter in 4.13 will resolve this.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
