### PR TITLE
Bug 2242269: external: fix client health checker user keyring return

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -173,7 +173,7 @@ jobs:
           kubectl -n rook-ceph exec $toolbox -- ceph auth ls
           # update the existing non-restricted client auth with the new ones
           kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --upgrade
-          # print ugraded client auth
+          # print upgraded client auth
           kubectl -n rook-ceph exec $toolbox -- ceph auth ls
 
       - name: test the upgrade flag for restricted auth user
@@ -184,7 +184,7 @@ jobs:
           # restricted auth user need to provide --rbd-data-pool-name,
           #  --cluster-name and --run-as-user flag while upgrading
           kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --cluster-name rookstorage  --run-as-user client.csi-rbd-node-rookstorage-replicapool
-          # print ugraded client auth
+          # print upgraded client auth
           kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-node-rookstorage-replicapool
 
       - name: validate-rgw-endpoint
@@ -1293,7 +1293,7 @@ jobs:
           # snaps=$(kubectl -n rook-ceph exec deploy/rook-ceph-fs-mirror -- ceph --admin-daemon /var/run/ceph/$mirror_daemon fs mirror peer status myfs@1 $clusterfsid|jq -r '."/volumes/_nogroup/testsubvolume"."snaps_synced"')
           # echo "snapshots: $snaps"
           # if [ $num_snaps_target = $snaps ]
-          # then echo "Snaphots have synced."
+          # then echo "Snapshots have synced."
           # else echo "Snaps have not synced. NEEDS INVESTIGATION"
           # fi
 

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md
@@ -189,7 +189,7 @@ kubectl create -f object-multisite-pull-realm.yaml
 ## Scaling a Multisite
 
 Scaling the number of gateways that run the synchronization thread to 2 or more can increase the latency of the
-replication of each S3 object. The recommended way to scale a mutisite configuration is to dissociate the gateway dedicated
+replication of each S3 object. The recommended way to scale a multisite configuration is to dissociate the gateway dedicated
 to the synchronization from gateways that serve clients.
 
 The two types of gateways can be deployed by creating two CephObjectStores associated with the same CephObjectZone. The

--- a/Documentation/Storage-Configuration/ceph-teardown.md
+++ b/Documentation/Storage-Configuration/ceph-teardown.md
@@ -116,7 +116,7 @@ partprobe $DISK
 ```
 
 Ceph can leave LVM and device mapper data that can lock the disks, preventing the disks from being
-used again. These steps can help to free up old Ceph disks for re-use. Note that this only needs to
+used again. These steps can help to free up old Ceph disks for reuse. Note that this only needs to
 be run once on each node. If you have **only one** Rook cluster and **all** Ceph disks are
 being wiped, run the following command.
 

--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -228,7 +228,7 @@ func GetInternalOrExternalClient() kubernetes.Interface {
 		for _, kConf := range strings.Split(kubeconfig, ":") {
 			restConfig, err = clientcmd.BuildConfigFromFlags("", kConf)
 			if err == nil {
-				logger.Debugf("attmepting to create kube clientset from kube config file %q", kConf)
+				logger.Debugf("attempting to create kube clientset from kube config file %q", kConf)
 				clientset, err = kubernetes.NewForConfig(restConfig)
 				if err == nil {
 					logger.Infof("created kube client interface from kube config file %q present in KUBECONFIG environment variable", kConf)

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -557,7 +557,7 @@ class RadosJSON:
             )
 
     def _invalid_endpoint(self, endpoint_str):
-        # seprating port, by getting last split of `:` delimiter
+        # separating port, by getting last split of `:` delimiter
         try:
             endpoint_str_ip, port = endpoint_str.rsplit(":", 1)
         except ValueError:

--- a/pkg/daemon/multus/validation.go
+++ b/pkg/daemon/multus/validation.go
@@ -113,7 +113,7 @@ func (s *getExpectedNumberOfImagePullPodsState) Run(
 }
 
 /*
- *  Re-usable state to verify that expected number of pods are "Running" but not necessarily "Ready"
+ *  Reusable state to verify that expected number of pods are "Running" but not necessarily "Ready"
  *    > Verify all image pull pods are running
  *        -- next state --> Delete image pull daemonset
  *    > Verify all client pods are running

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -302,7 +302,7 @@ func CommitConfigChanges(c *Context) error {
 		return errorOrIsNotFound(err, "failed to get the current RGW configuration period to see if it needs changed")
 	}
 
-	// this stages the current config changees and returns what the new period config will look like
+	// this stages the current config changes and returns what the new period config will look like
 	// without committing the changes
 	stagedPeriod, err := runAdminCommand(c, true, "period", "update")
 	if err != nil {

--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -49,7 +49,7 @@ func CreateBlockOperation(k8shelp *utils.K8sHelper, manifests installer.CephMani
 // BlockCreate Function to create a Block using Rook
 // Input parameters -
 // manifest - pod definition that creates a pvc in k8s - yaml should describe name and size of pvc being created
-// size - not user for k8s implementation since its descried on the pvc yaml definition
+// size - not user for k8s implementation since its described on the pvc yaml definition
 // Output - k8s create pvc operation output and/or error
 func (b *BlockOperation) Create(manifest string, size int) (string, error) {
 	args := []string{"apply", "-f", "-"}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

if the client.health checker already exited it was
returning extra information, It was making the structure and
return JSON non idempotent output, So fixed
that problem by returning a single value

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
