### PR TITLE
 Bug 2268174: external: change cluster_name to k8s_cluster_name

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -159,12 +159,12 @@ jobs:
       - name: test external script with restricted_auth_permission flag and without having cephfs_filesystem flag
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cluster-name rookstorage --restricted-auth-permission true
+          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage --restricted-auth-permission true
 
       - name: test external script with restricted_auth_permission flag
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --cluster-name rookstorage --restricted-auth-permission true
+          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage --restricted-auth-permission true
 
       - name: test the upgrade flag
         run: |
@@ -182,8 +182,8 @@ jobs:
           # print existing client auth
           kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-node-rookstorage-replicapool
           # restricted auth user need to provide --rbd-data-pool-name,
-          #  --cluster-name and --run-as-user flag while upgrading
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --cluster-name rookstorage  --run-as-user client.csi-rbd-node-rookstorage-replicapool
+          #  --k8s-cluster-name and --run-as-user flag while upgrading
+          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage  --run-as-user client.csi-rbd-node-rookstorage-replicapool
           # print upgraded client auth
           kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-node-rookstorage-replicapool
 

--- a/Documentation/CRDs/Cluster/external-cluster.md
+++ b/Documentation/CRDs/Cluster/external-cluster.md
@@ -45,7 +45,7 @@ python3 create-external-cluster-resources.py --rbd-data-pool-name <pool_name> --
 * `--skip-monitoring-endpoint`: (optional) Skip prometheus exporter endpoints, even if they are available. Useful if the prometheus module is not enabled
 * `--ceph-conf`: (optional) Provide a Ceph conf file
 * `--keyring`: (optional) Path to Ceph keyring file, to be used with `--ceph-conf`
-* `--cluster-name`: (optional) Ceph cluster name
+* `--k8s-cluster-name`: (optional) Kubernetes cluster name
 * `--output`: (optional) Output will be stored into the provided file
 * `--dry-run`: (optional) Prints the executed commands without running them
 * `--run-as-user`: (optional) Provides a user name to check the cluster's health status, must be prefixed by `client`.
@@ -58,7 +58,7 @@ python3 create-external-cluster-resources.py --rbd-data-pool-name <pool_name> --
 * `--rgw-zone-name`: (optional) Provides the name of the rgw-zone
 * `--rgw-zonegroup-name`: (optional) Provides the name of the rgw-zone-group
 * `--upgrade`: (optional) Upgrades the cephCSIKeyrings(For example: client.csi-cephfs-provisioner) and client.healthchecker ceph users with new permissions needed for the new cluster version and older permission will still be applied.
-* `--restricted-auth-permission`: (optional) Restrict cephCSIKeyrings auth permissions to specific pools, and cluster. Mandatory flags that need to be set are `--rbd-data-pool-name`, and `--cluster-name`. `--cephfs-filesystem-name` flag can also be passed in case of CephFS user restriction, so it can restrict users to particular CephFS filesystem.
+* `--restricted-auth-permission`: (optional) Restrict cephCSIKeyrings auth permissions to specific pools, and cluster. Mandatory flags that need to be set are `--rbd-data-pool-name`, and `--k8s-cluster-name`. `--cephfs-filesystem-name` flag can also be passed in case of CephFS user restriction, so it can restrict users to particular CephFS filesystem.
 * `--v2-port-enable`: (optional) Enables the v2 mon port (3300) for mons.
 
 ### Multi-tenancy
@@ -72,7 +72,7 @@ So you would be running different isolated consumer clusters on top of single `S
     So apply these secrets only to new `Consumer cluster` deployment while using the same `Source cluster`.
 
 ```console
-python3 create-external-cluster-resources.py --cephfs-filesystem-name <filesystem-name> --rbd-data-pool-name <pool_name> --cluster-name <cluster-name> --restricted-auth-permission true --format <bash> --rgw-endpoint <rgw_endpoin> --namespace <rook-ceph-external>
+python3 create-external-cluster-resources.py --cephfs-filesystem-name <filesystem-name> --rbd-data-pool-name <pool_name> --k8s-cluster-name <k8s-cluster-name> --restricted-auth-permission true --format <bash> --rgw-endpoint <rgw_endpoin> --namespace <rook-ceph-external>
 ```
 
 ### RGW Multisite
@@ -93,10 +93,10 @@ python3 create-external-cluster-resources.py --upgrade
 ```
 
 2) If the consumer cluster has restricted caps:
-Restricted users created using `--restricted-auth-permission` flag need to pass mandatory flags: '`--rbd-data-pool-name`(if it is a rbd user), `--cluster-name` and `--run-as-user`' flags while upgrading, in case of cephfs users if you have passed `--cephfs-filesystem-name` flag while creating csi-users then while upgrading it will be mandatory too. In this example the user would be `client.csi-rbd-node-rookstorage-replicapool` (following the pattern `csi-user-clusterName-poolName`)
+Restricted users created using `--restricted-auth-permission` flag need to pass mandatory flags: '`--rbd-data-pool-name`(if it is a rbd user), `--k8s-cluster-name` and `--run-as-user`' flags while upgrading, in case of cephfs users if you have passed `--cephfs-filesystem-name` flag while creating csi-users then while upgrading it will be mandatory too. In this example the user would be `client.csi-rbd-node-rookstorage-replicapool` (following the pattern `csi-user-clusterName-poolName`)
 
 ```console
-python3 create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --cluster-name rookstorage --run-as-user client.csi-rbd-node-rookstorage-replicapool
+python3 create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage --run-as-user client.csi-rbd-node-rookstorage-replicapool
 ```
 
 !!! note

--- a/deploy/examples/create-external-cluster-resources-tests.py
+++ b/deploy/examples/create-external-cluster-resources-tests.py
@@ -70,7 +70,7 @@ class TestRadosJSON(unittest.TestCase):
         )
         print(f"cephCSIKeyring without restricting it to a metadata pool. {csiKeyring}")
         self.rjObj._arg_parser.restricted_auth_permission = True
-        self.rjObj._arg_parser.cluster_name = "openshift-storage"
+        self.rjObj._arg_parser.k8s_cluster_name = "openshift-storage"
         csiKeyring = self.rjObj.create_cephCSIKeyring_user(
             "client.csi-cephfs-provisioner"
         )

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -324,7 +324,7 @@ class RadosJSON:
             help="Provides a user name to check the cluster's health status, must be prefixed by 'client.'",
         )
         common_group.add_argument(
-            "--cluster-name", default="", help="Ceph cluster name"
+            "--k8s-cluster-name", default="", help="Kubernetes cluster name"
         )
         common_group.add_argument(
             "--namespace",
@@ -338,9 +338,9 @@ class RadosJSON:
             "--restricted-auth-permission",
             default=False,
             help="Restrict cephCSIKeyrings auth permissions to specific pools, cluster."
-            + "Mandatory flags that need to be set are --rbd-data-pool-name, and --cluster-name."
+            + "Mandatory flags that need to be set are --rbd-data-pool-name, and --k8s-cluster-name."
             + "--cephfs-filesystem-name flag can also be passed in case of cephfs user restriction, so it can restrict user to particular cephfs filesystem"
-            + "sample run: `python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --cluster-name rookstorage --restricted-auth-permission true`"
+            + "sample run: `python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage --restricted-auth-permission true`"
             + "Note: Restricting the csi-users per pool, and per cluster will require creating new csi-users and new secrets for that csi-users."
             + "So apply these secrets only to new `Consumer cluster` deployment while using the same `Source cluster`.",
         )
@@ -479,9 +479,9 @@ class RadosJSON:
             help="Upgrades the cephCSIKeyrings(For example: client.csi-cephfs-provisioner) and client.healthchecker ceph users with new permissions needed for the new cluster version and older permission will still be applied."
             + "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade`, this will upgrade all the default csi users(non-restricted)"
             + "For restricted users(For example: client.csi-cephfs-provisioner-openshift-storage-myfs), users created using --restricted-auth-permission flag need to pass mandatory flags"
-            + "mandatory flags: '--rbd-data-pool-name, --cluster-name and --run-as-user' flags while upgrading"
+            + "mandatory flags: '--rbd-data-pool-name, --k8s-cluster-name and --run-as-user' flags while upgrading"
             + "in case of cephfs users if you have passed --cephfs-filesystem-name flag while creating user then while upgrading it will be mandatory too"
-            + "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --cluster-name rookstorage  --run-as-user client.csi-rbd-node-rookstorage-replicapool`"
+            + "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage  --run-as-user client.csi-rbd-node-rookstorage-replicapool`"
             + "PS: An existing non-restricted user cannot be converted to a restricted user by upgrading."
             + "Upgrade flag should only be used to append new permissions to users, it shouldn't be used for changing user already applied permission, for example you shouldn't change in which pool user has access",
         )
@@ -853,16 +853,16 @@ class RadosJSON:
             "osd": "allow rw tag cephfs metadata=*",
         }
         if self._arg_parser.restricted_auth_permission:
-            cluster_name = self._arg_parser.cluster_name
-            if cluster_name == "":
+            k8s_cluster_name = self._arg_parser.k8s_cluster_name
+            if k8s_cluster_name == "":
                 raise ExecutionFailureException(
-                    "cluster_name not found, please set the '--cluster-name' flag"
+                    "k8s_cluster_name not found, please set the '--k8s-cluster-name' flag"
                 )
             cephfs_filesystem = self._arg_parser.cephfs_filesystem_name
             if cephfs_filesystem == "":
-                entity = f"{entity}-{cluster_name}"
+                entity = f"{entity}-{k8s_cluster_name}"
             else:
-                entity = f"{entity}-{cluster_name}-{cephfs_filesystem}"
+                entity = f"{entity}-{k8s_cluster_name}-{cephfs_filesystem}"
                 caps["osd"] = f"allow rw tag cephfs metadata={cephfs_filesystem}"
 
         return caps, entity
@@ -876,21 +876,21 @@ class RadosJSON:
             "mds": "allow rw",
         }
         if self._arg_parser.restricted_auth_permission:
-            cluster_name = self._arg_parser.cluster_name
-            if cluster_name == "":
+            k8s_cluster_name = self._arg_parser.k8s_cluster_name
+            if k8s_cluster_name == "":
                 raise ExecutionFailureException(
-                    "cluster_name not found, please set the '--cluster-name' flag"
+                    "k8s_cluster_name not found, please set the '--k8s-cluster-name' flag"
                 )
             cephfs_filesystem = self._arg_parser.cephfs_filesystem_name
             if cephfs_filesystem == "":
-                entity = f"{entity}-{cluster_name}"
+                entity = f"{entity}-{k8s_cluster_name}"
             else:
-                entity = f"{entity}-{cluster_name}-{cephfs_filesystem}"
+                entity = f"{entity}-{k8s_cluster_name}-{cephfs_filesystem}"
                 caps["osd"] = f"allow rw tag cephfs *={cephfs_filesystem}"
 
         return caps, entity
 
-    def get_entity(self, entity, rbd_pool_name, alias_rbd_pool_name, cluster_name):
+    def get_entity(self, entity, rbd_pool_name, alias_rbd_pool_name, k8s_cluster_name):
         if (
             rbd_pool_name.count(".") != 0
             or rbd_pool_name.count("_") != 0
@@ -908,9 +908,9 @@ class RadosJSON:
                 raise ExecutionFailureException(
                     "'--alias-rbd-data-pool-name' flag value should not contain '.' or '_'"
                 )
-            entity = f"{entity}-{cluster_name}-{alias_rbd_pool_name}"
+            entity = f"{entity}-{k8s_cluster_name}-{alias_rbd_pool_name}"
         else:
-            entity = f"{entity}-{cluster_name}-{rbd_pool_name}"
+            entity = f"{entity}-{k8s_cluster_name}-{rbd_pool_name}"
 
         return entity
 
@@ -924,17 +924,17 @@ class RadosJSON:
         if self._arg_parser.restricted_auth_permission:
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
             alias_rbd_pool_name = self._arg_parser.alias_rbd_data_pool_name
-            cluster_name = self._arg_parser.cluster_name
+            k8s_cluster_name = self._arg_parser.k8s_cluster_name
             if rbd_pool_name == "":
                 raise ExecutionFailureException(
                     "mandatory flag not found, please set the '--rbd-data-pool-name' flag"
                 )
-            if cluster_name == "":
+            if k8s_cluster_name == "":
                 raise ExecutionFailureException(
-                    "mandatory flag not found, please set the '--cluster-name' flag"
+                    "mandatory flag not found, please set the '--k8s-cluster-name' flag"
                 )
             entity = self.get_entity(
-                entity, rbd_pool_name, alias_rbd_pool_name, cluster_name
+                entity, rbd_pool_name, alias_rbd_pool_name, k8s_cluster_name
             )
             caps["osd"] = f"profile rbd pool={rbd_pool_name}"
 
@@ -949,17 +949,17 @@ class RadosJSON:
         if self._arg_parser.restricted_auth_permission:
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
             alias_rbd_pool_name = self._arg_parser.alias_rbd_data_pool_name
-            cluster_name = self._arg_parser.cluster_name
+            k8s_cluster_name = self._arg_parser.k8s_cluster_name
             if rbd_pool_name == "":
                 raise ExecutionFailureException(
                     "mandatory flag not found, please set the '--rbd-data-pool-name' flag"
                 )
-            if cluster_name == "":
+            if k8s_cluster_name == "":
                 raise ExecutionFailureException(
-                    "mandatory flag not found, please set the '--cluster-name' flag"
+                    "mandatory flag not found, please set the '--k8s-cluster-name' flag"
                 )
             entity = self.get_entity(
-                entity, rbd_pool_name, alias_rbd_pool_name, cluster_name
+                entity, rbd_pool_name, alias_rbd_pool_name, k8s_cluster_name
             )
             caps["osd"] = f"profile rbd pool={rbd_pool_name}"
 
@@ -1463,15 +1463,15 @@ class RadosJSON:
     def _gen_output_map(self):
         if self.out_map:
             return
-        self._arg_parser.cluster_name = (
-            self._arg_parser.cluster_name.lower()
+        self._arg_parser.k8s_cluster_name = (
+            self._arg_parser.k8s_cluster_name.lower()
         )  # always convert cluster name to lowercase characters
         self.validate_rbd_pool()
         self.validate_rados_namespace()
-        self._excluded_keys.add("CLUSTER_NAME")
+        self._excluded_keys.add("K8S_CLUSTER_NAME")
         self.get_cephfs_data_pool_details()
         self.out_map["NAMESPACE"] = self._arg_parser.namespace
-        self.out_map["CLUSTER_NAME"] = self._arg_parser.cluster_name
+        self.out_map["K8S_CLUSTER_NAME"] = self._arg_parser.k8s_cluster_name
         self.out_map["ROOK_EXTERNAL_FSID"] = self.get_fsid()
         self.out_map["ROOK_EXTERNAL_USERNAME"] = self.run_as_user
         self.out_map["ROOK_EXTERNAL_CEPH_MON_DATA"] = self.get_ceph_external_mon_data()


### PR DESCRIPTION
it was confusing if we are calling a ceph cluster name or k8s cluster name, so re-named


(cherry picked from commit 98c4567219198e8d13f35ed4c75b6ff000c3d12e)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
