### PR TITLE
Bug 2245978: multus: use rook image for ip range detection

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -40,7 +40,7 @@ jobs:
           python-version: 3.9
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (lint)
         run: ct lint --charts=./deploy/charts/rook-ceph --validate-yaml=false --validate-maintainers=false

--- a/build/csv/csv-gen.sh
+++ b/build/csv/csv-gen.sh
@@ -43,11 +43,13 @@ function generate_csv() {
     # This change are just to make the CSV file as it was earlier and as ocs-operator reads.
     # Skipping this change for darwin since `sed -i` doesn't work with darwin properly.
     # and the csv is not ever needed in the mac builds.
-    if [[ "$OSTYPE" != "darwin"* ]]; then
-        sed -i 's/image: rook\/ceph:.*/image: {{.RookOperatorImage}}/g' "$CSV_FILE_NAME"
-        sed -i 's/name: rook-ceph.v.*/name: rook-ceph.v{{.RookOperatorCsvVersion}}/g' "$CSV_FILE_NAME"
-        sed -i 's/version: 0.0.0/version: {{.RookOperatorCsvVersion}}/g' "$CSV_FILE_NAME"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        return
     fi
+
+    sed -i 's/image: rook\/ceph:.*/image: {{.RookOperatorImage}}/g' "$CSV_FILE_NAME"
+    sed -i 's/name: rook-ceph.v.*/name: rook-ceph.v{{.RookOperatorCsvVersion}}/g' "$CSV_FILE_NAME"
+    sed -i 's/version: 0.0.0/version: {{.RookOperatorCsvVersion}}/g' "$CSV_FILE_NAME"
 
     mv "$CSV_FILE_NAME" "../../build/csv/"
     mv "../../build/csv/ceph/$PLATFORM/manifests/"* "../../build/csv/ceph/"

--- a/build/release/requirements_docs.txt
+++ b/build/release/requirements_docs.txt
@@ -3,7 +3,7 @@ mkdocs
 mkdocs-awesome-pages-plugin
 mkdocs-exclude
 mkdocs-macros-plugin
-mkdocs-material==8.*
+mkdocs-material
 mkdocs-material-extensions
 mkdocs-minify-plugin
 mkdocs-redirects

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Rook Ceph Documentation
 docs_dir: Documentation/
-site_url: 'https://rook.io'
+site_url: "https://rook.io"
 repo_url: https://github.com/rook/rook
 edit_uri: edit/master/Documentation/
 site_author: Rook Authors
@@ -26,15 +26,15 @@ theme:
   favicon: https://rook.io/images/favicon_192x192.png
   logo: https://rook.io/images/rook-logo.svg
   palette:
-    - scheme: 'default'
-      primary: 'rook-blue'
-      accent: 'deep orange'
+    - scheme: "default"
+      primary: "rook-blue"
+      accent: "deep orange"
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
-    - scheme: 'slate'
-      primary: 'rook-blue'
-      accent: 'red'
+    - scheme: "slate"
+      primary: "rook-blue"
+      accent: "red"
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode
@@ -75,10 +75,11 @@ plugins:
         README.md: Getting-Started/intro.md
   - mike:
       # these fields are all optional; the defaults are as below...
-      version_selector: true   # set to false to leave out the version selector
-      css_dir: css             # the directory to put the version selector's CSS
-      javascript_dir: js       # the directory to put the version selector's JS
-      canonical_version: null  # the version for <link rel="canonical">; `null`
+      version_selector: true # set to false to leave out the version selector
+      css_dir: css # the directory to put the version selector's CSS
+      javascript_dir: js # the directory to put the version selector's JS
+      canonical_version:
+        null # the version for <link rel="canonical">; `null`
         # uses the version specified via `mike deploy`
 markdown_extensions:
   - admonition
@@ -91,8 +92,8 @@ markdown_extensions:
   - tables
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
       use_pygments: true
@@ -116,6 +117,6 @@ extra:
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/rook_io
     - icon: fontawesome/solid/envelopes-bulk
-      link: 'https://groups.google.com/forum/#!forum/rook-dev'
+      link: "https://groups.google.com/forum/#!forum/rook-dev"
     - icon: fontawesome/brands/medium
       link: https://blog.rook.io/

--- a/pkg/operator/ceph/controller/network.go
+++ b/pkg/operator/ceph/controller/network.go
@@ -251,7 +251,7 @@ func discoverAddressRanges(
 			`},
 		[]string{},
 		rookImage,
-		clusterSpec.CephVersion.Image,
+		rookImage,
 		clusterSpec.CephVersion.ImagePullPolicy,
 	)
 	if err != nil {
@@ -273,7 +273,7 @@ func discoverAddressRanges(
 	netStatusVol, netStatusMount := networkStatusVolumeAndMount()
 	job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, netStatusVol)
 	job.Spec.Template.Spec.Containers[0].VolumeMounts = append(job.Spec.Template.Spec.Containers[0].VolumeMounts, netStatusMount)
-	job.Spec.Template.Spec.InitContainers = append(job.Spec.Template.Spec.InitContainers, containerWaitForNetworkStatus(clusterSpec))
+	job.Spec.Template.Spec.InitContainers = append(job.Spec.Template.Spec.InitContainers, containerWaitForNetworkStatus(clusterSpec, rookImage))
 
 	stdout, stderr, retcode, err := networkCanary.Run(ctx, detectNetworkCIDRTimeout)
 	if err != nil {
@@ -354,7 +354,7 @@ func networkStatusVolumeAndMount() (corev1.Volume, corev1.VolumeMount) {
 // to wait until the network status annotation is present to output info before running so that it
 // reports all the info. separate step of waiting for network status annotation into an init
 // container so that it can be more easily debugged (output not present in cmd reporter's result)
-func containerWaitForNetworkStatus(clusterSpec *cephv1.ClusterSpec) corev1.Container {
+func containerWaitForNetworkStatus(clusterSpec *cephv1.ClusterSpec, rookImage string) corev1.Container {
 	_, mount := networkStatusVolumeAndMount()
 	return corev1.Container{
 		Name: "wait-for-network-status-annotation",
@@ -370,7 +370,7 @@ func containerWaitForNetworkStatus(clusterSpec *cephv1.ClusterSpec) corev1.Conta
 			echo "" # newline
 			`,
 		},
-		Image:           clusterSpec.CephVersion.Image,
+		Image:           rookImage,
 		ImagePullPolicy: clusterSpec.CephVersion.ImagePullPolicy,
 		VolumeMounts: []corev1.VolumeMount{
 			mount,


### PR DESCRIPTION
Use the Rook image (defined by the operator pod) to detect the Multus network address ranges. It is reasonable for users to want to have a minimal Ceph image that does not have the `ip` utility installed, which is used for detecting the address ranges of multus interfaces. Instead, use the Rook image, which Rook can ensure has the `ip` tool if Ceph ever removes it from their image.

Signed-off-by: Blaine Gardner <blaine.gardner@ibm.com>
(cherry picked from commit 8aec30aa5a22a4051db01b4b182fa67a9e2c3960)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
