### PR TITLE
Bug 2248850: exporter: run exporter with specific keyring

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -489,6 +489,12 @@ func (c *cluster) postMonStartupActions() error {
 		return errors.Wrap(err, "failed to create crash collector kubernetes secret")
 	}
 
+	// Create exporter Kubernetes Secret
+	err = nodedaemon.CreateExporterSecret(c.context, c.ClusterInfo)
+	if err != nil {
+		return errors.Wrap(err, "failed to create exporter kubernetes secret")
+	}
+
 	// Always ensure the skip mds sanity checks setting is cleared, for all Pacific deployments
 	if c.ClusterInfo.CephVersion.IsPacific() {
 		if err := c.skipMDSSanityChecks(false); err != nil {

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -47,6 +47,8 @@ const (
 	statsPeriod                      = "5"
 	DefaultMetricsPort        uint16 = 9926
 	exporterServiceMetricName        = "ceph-exporter-http-metrics"
+	exporterKeyringUsername          = "client.ceph-exporter"
+	exporterKeyName                  = "rook-ceph-exporter-keyring"
 )
 
 var (
@@ -81,7 +83,7 @@ func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations
 
 	volumes := append(
 		controller.DaemonVolumesBase(config.NewDatalessDaemonDataPathMap(cephCluster.GetNamespace(), cephCluster.Spec.DataDirHostPath), "", cephCluster.Spec.DataDirHostPath),
-		keyring.Volume().Admin())
+		keyring.Volume().Exporter())
 
 	mutateFunc := func() error {
 
@@ -165,12 +167,10 @@ func getCephExporterDaemonContainer(cephCluster cephv1.CephCluster, cephVersion 
 	cephImage := cephCluster.Spec.CephVersion.Image
 	dataPathMap := config.NewDatalessDaemonDataPathMap(cephCluster.GetNamespace(), cephCluster.Spec.DataDirHostPath)
 	volumeMounts := controller.DaemonVolumeMounts(dataPathMap, "", cephCluster.Spec.DataDirHostPath)
-	// FIX: Use an exporter keyring instead of the admin keyring
-	volumeMounts = append(volumeMounts, keyring.VolumeMount().Admin())
+	volumeMounts = append(volumeMounts, keyring.VolumeMount().Exporter())
 
-	envVars := append(
-		controller.DaemonEnvVars(&cephCluster.Spec),
-		v1.EnvVar{Name: "CEPH_ARGS", Value: fmt.Sprintf("-m $(ROOK_CEPH_MON_HOST) -k %s", keyring.VolumeMount().AdminKeyringFilePath())})
+	exporterEnvVar := generateExporterEnvVar()
+	envVars := append(controller.DaemonEnvVars(&cephCluster.Spec), exporterEnvVar)
 
 	container := corev1.Container{
 		Name:            "ceph-exporter",
@@ -264,4 +264,11 @@ func applyPrometheusAnnotations(cephCluster cephv1.CephCluster, objectMeta *meta
 
 		t.ApplyToObjectMeta(objectMeta)
 	}
+}
+
+func generateExporterEnvVar() corev1.EnvVar {
+	val := fmt.Sprintf("-m $(ROOK_CEPH_MON_HOST) -n %s -k %s", exporterKeyringUsername, keyring.VolumeMount().ExporterKeyringFilePath())
+	env := corev1.EnvVar{Name: "CEPH_ARGS", Value: val}
+
+	return env
 }

--- a/pkg/operator/ceph/cluster/nodedaemon/keyring_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring_test.go
@@ -26,3 +26,8 @@ func TestCephCrashCollectorKeyringCaps(t *testing.T) {
 	caps := cephCrashCollectorKeyringCaps()
 	assert.Equal(t, caps, []string{"mon", "allow profile crash", "mgr", "allow rw"})
 }
+
+func TestExporterKeyringCaps(t *testing.T) {
+	caps := createExporterKeyringCaps()
+	assert.Equal(t, caps, []string{"mon", "allow profile ceph-exporter", "mgr", "allow r", "osd", "allow r", "mds", "allow r"})
+}

--- a/pkg/operator/ceph/config/keyring/admin.go
+++ b/pkg/operator/ceph/config/keyring/admin.go
@@ -29,6 +29,7 @@ import (
 const (
 	adminKeyringResourceName          = "rook-ceph-admin"
 	crashCollectorKeyringResourceName = "rook-ceph-crash-collector"
+	exporterKeyringResourceName       = "rook-ceph-exporter"
 
 	adminKeyringTemplate = `
 [client.admin]

--- a/pkg/operator/ceph/config/keyring/volume.go
+++ b/pkg/operator/ceph/config/keyring/volume.go
@@ -13,6 +13,7 @@ const (
 	// mounted independently
 	adminKeyringDir          = "/etc/ceph/admin-keyring-store/"
 	crashCollectorKeyringDir = "/etc/ceph/crash-collector-keyring-store/"
+	exporterKeyringDir       = "/etc/ceph/exporter-keyring-store/"
 )
 
 // VolumeBuilder is a helper for creating Kubernetes pod volumes with content sourced by keyrings
@@ -45,6 +46,11 @@ func (v *VolumeBuilder) Admin() v1.Volume {
 // CrashCollector returns a kubernetes pod volume whose content is sourced by the SecretStore crash collector keyring.
 func (v *VolumeBuilder) CrashCollector() v1.Volume {
 	return v.Resource(crashCollectorKeyringResourceName)
+}
+
+// Exporter returns a kubernetes pod volume whose content is sourced by the SecretStore exporter keyring.
+func (v *VolumeBuilder) Exporter() v1.Volume {
+	return v.Resource(exporterKeyringResourceName)
 }
 
 // VolumeMount returns a VolumeMountBuilder.
@@ -80,6 +86,16 @@ func (*VolumeMountBuilder) CrashCollector() v1.VolumeMount {
 	}
 }
 
+// Exporter returns a Kubernetes container volume mount that mounts the content from the matching
+// VolumeBuilder Exporter volume.
+func (*VolumeMountBuilder) Exporter() v1.VolumeMount {
+	return v1.VolumeMount{
+		Name:      keyringSecretName(exporterKeyringResourceName),
+		ReadOnly:  true, // should be no reason to write to the keyring in pods, so enforce this
+		MountPath: exporterKeyringDir,
+	}
+}
+
 // KeyringFilePath returns the full path to the regular keyring file within a container.
 func (*VolumeMountBuilder) KeyringFilePath() string {
 	return path.Join(keyringDir, keyringFileName)
@@ -93,4 +109,9 @@ func (*VolumeMountBuilder) AdminKeyringFilePath() string {
 // CrashCollectorKeyringFilePath returns the full path to the admin keyring file within a container.
 func (*VolumeMountBuilder) CrashCollectorKeyringFilePath() string {
 	return path.Join(crashCollectorKeyringDir, keyringFileName)
+}
+
+// ExporterKeyringFilePath returns the full path to the admin keyring file within a container.
+func (*VolumeMountBuilder) ExporterKeyringFilePath() string {
+	return path.Join(exporterKeyringDir, keyringFileName)
 }


### PR DESCRIPTION
Similar to the ceph crash collector daemon that generates a keyring with more restrictive privileges, the exporter should also generate and use a more limited keyring.

Signed-off-by: avanthakkar <avanjohn@gmail.com>
(cherry picked from commit 8fa561484a134c396763b359507d997490986389)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
