### PR TITLE
Bug 2248850: exporter: change deployment strategy to Recreate

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -118,6 +118,11 @@ func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations
 		if cephVersion != nil {
 			controller.AddCephVersionLabelToDeployment(*cephVersion, deploy)
 		}
+
+		// wait for previous exporter pod to be deleted, before creating a new one
+		// to avoid fighting for the same socket file
+		deploy.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
+
 		var terminationGracePeriodSeconds int64 = 2
 		deploy.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Restarting the exporter using RollingRelease causes a race condition, that results in exporter crashing and the ceph health to show a warning.

This commit, changes the deployment strategy to Recreate. So that we wait for the exporter pods to completely terminate before we create a new one.