### PR TITLE
Bug 2257296: nfs: enable the rpc liveness probe in d/s 4.15

### DIFF
--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -255,7 +255,7 @@ func (r *ReconcileCephNFS) daemonContainer(nfs *cephv1.CephNFS, cfg daemonConfig
 
 func (r *ReconcileCephNFS) defaultGaneshaLivenessProbe(nfs *cephv1.CephNFS) *v1.Probe {
 	failureThreshold := int32(10)
-	cephVersionWithRpcinfo := version.CephVersion{Major: 18, Minor: 2, Extra: 1}
+	cephVersionWithRpcinfo := version.CephVersion{Major: 17, Minor: 2, Extra: 6}
 	if r.clusterInfo.CephVersion.IsAtLeast(cephVersionWithRpcinfo) {
 		// liveness-probe using rpcinfo utility
 		return controller.GenerateLivenessProbeViaRpcinfo(nfsPort, failureThreshold)


### PR DESCRIPTION
In downstream, the RPC liveness probe is available in quincy (17.2.6) which is earlier than its availability upstream (18.2.1). Make a d/s-only patch to reflect this.

This is a similar tactic to what we used here: https://github.com/red-hat-storage/rook/pull/551

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
