### PR TITLE
Bug 2257371: external: include 255 as a valid ip range

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -549,7 +549,7 @@ class RadosJSON:
                     f"IP address parts should be numbers: {ipv4}"
                 )
             intPart = int(eachPart)
-            if intPart < 0 or intPart > 254:
+            if intPart < 0 or intPart > 255:
                 raise ExecutionFailureException(f"Out of range IP addresses: {ipv4}")
         if not port.isdigit():
             raise ExecutionFailureException(f"Port not valid: {port}")


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
external: include 255 as a valid ip range
    
    external script was checking ip range up to 254
    which is incorrect, the valid range is 0-255
    and if someone passes 255 it will through error like
    ```
    Out of range IP addresses
    ```
    so including 255 as a valid range.



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
