### PR TITLE
Bug 2254345: [release-4.14] external - fix the run as a user flag

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -965,8 +965,8 @@ class RadosJSON:
 
         return caps, entity
 
-    def get_healthchecker_caps_and_entity(self):
-        entity = "client.healthchecker"
+    def get_defaultUser_caps_and_entity(self):
+        entity = self.run_as_user
         caps = {
             "mon": "allow r, allow command quorum_status, allow command version",
             "mgr": "allow command config",
@@ -995,7 +995,7 @@ class RadosJSON:
         if "client.healthchecker" in user_name:
             if "client.healthchecker" != user_name:
                 self._arg_parser.restricted_auth_permission = True
-            return self.get_healthchecker_caps_and_entity()
+            return self.get_defaultUser_caps_and_entity()
 
         raise ExecutionFailureException(
             f"no user found with user_name: {user_name}, "


### PR DESCRIPTION
there is a hardcoded value of "client.healthchecker" which needs to be replaced by self.run_as_user

Signed-off-by: parth-gr <partharora1010@gmail.com>
(cherry picked from commit 8d89faf615d9437ff2b66e8f12aec70c1958b14f)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
