### PR TITLE
Bug 2258861: exporter: Don't delete exporter service on daemon deletion

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -99,22 +99,22 @@ class DummyRados(object):
         ) as json_file:
             ceph_status_str = json_file.read()
         self.cmd_names["fs ls"] = """{"format": "json", "prefix": "fs ls"}"""
-        self.cmd_names[
-            "quorum_status"
-        ] = """{"format": "json", "prefix": "quorum_status"}"""
-        self.cmd_names[
-            "mgr services"
-        ] = """{"format": "json", "prefix": "mgr services"}"""
+        self.cmd_names["quorum_status"] = (
+            """{"format": "json", "prefix": "quorum_status"}"""
+        )
+        self.cmd_names["mgr services"] = (
+            """{"format": "json", "prefix": "mgr services"}"""
+        )
         # all the commands and their output
-        self.cmd_output_map[
-            self.cmd_names["fs ls"]
-        ] = """[{"name":"myfs","metadata_pool":"myfs-metadata","metadata_pool_id":2,"data_pool_ids":[3],"data_pools":["myfs-replicated"]}]"""
-        self.cmd_output_map[
-            self.cmd_names["quorum_status"]
-        ] = """{"election_epoch":3,"quorum":[0],"quorum_names":["a"],"quorum_leader_name":"a","quorum_age":14385,"features":{"quorum_con":"4540138292836696063","quorum_mon":["kraken","luminous","mimic","osdmap-prune","nautilus","octopus"]},"monmap":{"epoch":1,"fsid":"af4e1673-0b72-402d-990a-22d2919d0f1c","modified":"2020-05-07T03:36:39.918035Z","created":"2020-05-07T03:36:39.918035Z","min_mon_release":15,"min_mon_release_name":"octopus","features":{"persistent":["kraken","luminous","mimic","osdmap-prune","nautilus","octopus"],"optional":[]},"mons":[{"rank":0,"name":"a","public_addrs":{"addrvec":[{"type":"v2","addr":"10.110.205.174:3300","nonce":0},{"type":"v1","addr":"10.110.205.174:6789","nonce":0}]},"addr":"10.110.205.174:6789/0","public_addr":"10.110.205.174:6789/0","priority":0,"weight":0}]}}"""
-        self.cmd_output_map[
-            self.cmd_names["mgr services"]
-        ] = """{"dashboard":"https://ceph-dashboard:8443/","prometheus":"http://ceph-dashboard-db:9283/"}"""
+        self.cmd_output_map[self.cmd_names["fs ls"]] = (
+            """[{"name":"myfs","metadata_pool":"myfs-metadata","metadata_pool_id":2,"data_pool_ids":[3],"data_pools":["myfs-replicated"]}]"""
+        )
+        self.cmd_output_map[self.cmd_names["quorum_status"]] = (
+            """{"election_epoch":3,"quorum":[0],"quorum_names":["a"],"quorum_leader_name":"a","quorum_age":14385,"features":{"quorum_con":"4540138292836696063","quorum_mon":["kraken","luminous","mimic","osdmap-prune","nautilus","octopus"]},"monmap":{"epoch":1,"fsid":"af4e1673-0b72-402d-990a-22d2919d0f1c","modified":"2020-05-07T03:36:39.918035Z","created":"2020-05-07T03:36:39.918035Z","min_mon_release":15,"min_mon_release_name":"octopus","features":{"persistent":["kraken","luminous","mimic","osdmap-prune","nautilus","octopus"],"optional":[]},"mons":[{"rank":0,"name":"a","public_addrs":{"addrvec":[{"type":"v2","addr":"10.110.205.174:3300","nonce":0},{"type":"v1","addr":"10.110.205.174:6789","nonce":0}]},"addr":"10.110.205.174:6789/0","public_addr":"10.110.205.174:6789/0","priority":0,"weight":0}]}}"""
+        )
+        self.cmd_output_map[self.cmd_names["mgr services"]] = (
+            """{"dashboard":"https://ceph-dashboard:8443/","prometheus":"http://ceph-dashboard-db:9283/"}"""
+        )
         self.cmd_output_map[
             """{"caps": ["mon", "allow r, allow command quorum_status", "osd", "profile rbd-read-only, allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow x pool=default.rgw.buckets.index"], "entity": "client.healthchecker", "format": "json", "prefix": "auth get-or-create"}"""
         ] = """[{"entity":"client.healthchecker","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon":"allow r, allow command quorum_status","osd":"profile rbd-read-only, allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow x pool=default.rgw.buckets.index"}}]"""
@@ -142,9 +142,9 @@ class DummyRados(object):
         self.cmd_output_map[
             """{"caps": ["mon", "allow r, allow command quorum_status, allow command version", "mgr", "allow command config", "osd", "profile rbd-read-only, allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow rx pool=default.rgw.log, allow x pool=default.rgw.buckets.index"], "entity": "client.healthchecker", "format": "json", "prefix": "auth caps"}"""
         ] = """[{"entity":"client.healthchecker","key":"AQDFkbNeft5bFRAATndLNUSRKruozxiZi3lrdA==","caps":{"mon": "allow r, allow command quorum_status, allow command version", "mgr": "allow command config", "osd": "profile rbd-read-only, allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow rx pool=default.rgw.log, allow x pool=default.rgw.buckets.index"}}]"""
-        self.cmd_output_map[
-            """{"format": "json", "prefix": "mgr services"}"""
-        ] = """{"dashboard": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:7000/", "prometheus": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:9283/"}"""
+        self.cmd_output_map["""{"format": "json", "prefix": "mgr services"}"""] = (
+            """{"dashboard": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:7000/", "prometheus": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:9283/"}"""
+        )
         self.cmd_output_map[
             """{"entity": "client.healthchecker", "format": "json", "prefix": "auth get"}"""
         ] = """{"dashboard": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:7000/", "prometheus": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:9283/"}"""
@@ -218,7 +218,6 @@ class DummyRados(object):
 
 
 class S3Auth(AuthBase):
-
     """Attaches AWS Authentication to the given Request object."""
 
     service_base_url = "s3.amazonaws.com"
@@ -954,9 +953,9 @@ class RadosJSON:
                 rados_namespace,
             )
             if rados_namespace != "":
-                caps[
-                    "osd"
-                ] = f"profile rbd pool={rbd_pool_name} namespace={rados_namespace}"
+                caps["osd"] = (
+                    f"profile rbd pool={rbd_pool_name} namespace={rados_namespace}"
+                )
             else:
                 caps["osd"] = f"profile rbd pool={rbd_pool_name}"
 
@@ -989,9 +988,9 @@ class RadosJSON:
                 rados_namespace,
             )
             if rados_namespace != "":
-                caps[
-                    "osd"
-                ] = f"profile rbd pool={rbd_pool_name} namespace={rados_namespace}"
+                caps["osd"] = (
+                    f"profile rbd pool={rbd_pool_name} namespace={rados_namespace}"
+                )
             else:
                 caps["osd"] = f"profile rbd pool={rbd_pool_name}"
 
@@ -1534,13 +1533,13 @@ class RadosJSON:
             self.out_map["CSI_RBD_PROVISIONER_SECRET_NAME"],
         ) = self.create_cephCSIKeyring_user("client.csi-rbd-provisioner")
         self.out_map["CEPHFS_POOL_NAME"] = self._arg_parser.cephfs_data_pool_name
-        self.out_map[
-            "CEPHFS_METADATA_POOL_NAME"
-        ] = self._arg_parser.cephfs_metadata_pool_name
+        self.out_map["CEPHFS_METADATA_POOL_NAME"] = (
+            self._arg_parser.cephfs_metadata_pool_name
+        )
         self.out_map["CEPHFS_FS_NAME"] = self._arg_parser.cephfs_filesystem_name
-        self.out_map[
-            "RESTRICTED_AUTH_PERMISSION"
-        ] = self._arg_parser.restricted_auth_permission
+        self.out_map["RESTRICTED_AUTH_PERMISSION"] = (
+            self._arg_parser.restricted_auth_permission
+        )
         self.out_map["RADOS_NAMESPACE"] = self._arg_parser.rados_namespace
         self.out_map["SUBVOLUME_GROUP"] = self._arg_parser.subvolume_group
         self.out_map["CSI_CEPHFS_NODE_SECRET"] = ""
@@ -1583,9 +1582,9 @@ class RadosJSON:
                 self.out_map["MONITORING_ENDPOINT_PORT"],
             ) = self.get_active_and_standby_mgrs()
         self.out_map["RBD_POOL_NAME"] = self._arg_parser.rbd_data_pool_name
-        self.out_map[
-            "RBD_METADATA_EC_POOL_NAME"
-        ] = self.validate_rbd_metadata_ec_pool_name()
+        self.out_map["RBD_METADATA_EC_POOL_NAME"] = (
+            self.validate_rbd_metadata_ec_pool_name()
+        )
         self.out_map["RGW_POOL_PREFIX"] = self._arg_parser.rgw_pool_prefix
         self.out_map["RGW_ENDPOINT"] = ""
         if self._arg_parser.rgw_endpoint:
@@ -1624,9 +1623,9 @@ class RadosJSON:
                     ) = self.create_rgw_admin_ops_user()
                     err = self.validate_rgw_endpoint(info_cap_supported)
                     if self._arg_parser.rgw_tls_cert_path:
-                        self.out_map[
-                            "RGW_TLS_CERT"
-                        ] = self.validate_rgw_endpoint_tls_cert()
+                        self.out_map["RGW_TLS_CERT"] = (
+                            self.validate_rgw_endpoint_tls_cert()
+                        )
                     # if there is no error, set the RGW_ENDPOINT
                     if err != "-1":
                         self.out_map["RGW_ENDPOINT"] = self._arg_parser.rgw_endpoint

--- a/tests/scripts/pythonwebserver/server.py
+++ b/tests/scripts/pythonwebserver/server.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 #!/usr/bin/env python3
 """
 Very simple HTTP server in python for logging requests


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The exporter service and service monitor should not be deleted if an individual daemon is being removed from a node. As long as the exporter is enabled with v18 and newer, the exporter service and service monitor should exist. Clusters were seeing their metrics stop collection when the exporter service and service monitor would disappear, especially when multiple clusters are configured.

**Which issue is resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=2258861

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
