### PR TITLE
Bug 2259668: csi: update network fence CR name

### DIFF
--- a/pkg/operator/ceph/cluster/watcher.go
+++ b/pkg/operator/ceph/cluster/watcher.go
@@ -533,9 +533,6 @@ func (c *clientCluster) createNetworkFence(ctx context.Context, pv corev1.Persis
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fenceResourceName(node.Name, driver),
 			Namespace: cluster.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(cluster, cephv1.SchemeGroupVersion.WithKind("CephCluster")),
-			},
 		},
 		Spec: addonsv1alpha1.NetworkFenceSpec{
 			Driver:     pv.Spec.CSI.Driver,


### PR DESCRIPTION
this commit updates the name of network fence CR to node name + driver name, which will allow the creation of multiple network fence per drivers on the same node, and modifies the unit test and deletion procedure for the same.

Signed-off-by: Riya Singhal <rsinghal@redhat.com>
(cherry picked from commit c2e3cf367c330fb8714c878eda8b3ae68ecc650a)

core: remove ownerRef from networkFence
since networkFence is a cluster-based resource so that we don't need
the namespace and ownerReferences as it cause garbage-collector errors.

Signed-off-by: subhamkrai <srai@redhat.com>
(cherry picked from commit https://github.com/red-hat-storage/rook/commit/2ac418a3b2ba689a53b9ec65596dbe225c0dce89)
(cherry picked from commit https://github.com/red-hat-storage/rook/commit/0113cc85c53564dcd5adb818a53b05a47aa76142)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
