### PR TITLE
Bug 2262070: core: remove namespace/ownerRef from networkFence

### DIFF
--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
     verbs: ["create"]
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["networkfences"]
-    verbs: ["create", "get", "update", "delete", "watch", "list"]
+    verbs: ["create", "get", "update", "delete", "watch", "list", "deletecollection"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get"]

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -563,7 +563,7 @@ rules:
     verbs: ["create"]
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["networkfences"]
-    verbs: ["create", "get", "update", "delete", "watch", "list"]
+    verbs: ["create", "get", "update", "delete", "watch", "list", "deletecollection"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get"]

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -21,11 +21,14 @@ import (
 	"testing"
 	"time"
 
+	addonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/csiaddons/v1alpha1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	apifake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,11 +74,14 @@ func TestReconcileDeleteCephCluster(t *testing.T) {
 	// create a Rook-Ceph scheme to use for our tests
 	scheme := runtime.NewScheme()
 	assert.NoError(t, cephv1.AddToScheme(scheme))
+	assert.NoError(t, addonsv1alpha1.AddToScheme(scheme))
 
 	t.Run("deletion blocked while dependencies exist", func(t *testing.T) {
 		// set up clusterd.Context
 		clusterdCtx := &clusterd.Context{
-			Clientset: k8sfake.NewSimpleClientset(),
+			Clientset:           k8sfake.NewSimpleClientset(),
+			RookClientset:       rookclient.NewSimpleClientset(),
+			ApiExtensionsClient: apifake.NewSimpleClientset(),
 		}
 
 		// create the cluster controller and tell it that the cluster has been deleted

--- a/pkg/operator/ceph/cluster/watcher_test.go
+++ b/pkg/operator/ceph/cluster/watcher_test.go
@@ -353,11 +353,11 @@ func TestHandleNodeFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	networkFenceRbd := &addonsv1alpha1.NetworkFence{}
-	err = c.client.Get(ctx, types.NamespacedName{Name: fenceResourceName(node.Name, rbdDriver), Namespace: cephCluster.Namespace}, networkFenceRbd)
+	err = c.client.Get(ctx, types.NamespacedName{Name: fenceResourceName(node.Name, rbdDriver, ns)}, networkFenceRbd)
 	assert.NoError(t, err)
 
 	networkFenceCephFs := &addonsv1alpha1.NetworkFence{}
-	err = c.client.Get(ctx, types.NamespacedName{Name: fenceResourceName(node.Name, cephfsDriver), Namespace: cephCluster.Namespace}, networkFenceCephFs)
+	err = c.client.Get(ctx, types.NamespacedName{Name: fenceResourceName(node.Name, cephfsDriver, ns)}, networkFenceCephFs)
 	assert.NoError(t, err)
 
 	networkFences := &addonsv1alpha1.NetworkFenceList{}
@@ -367,12 +367,10 @@ func TestHandleNodeFailure(t *testing.T) {
 
 	for _, fence := range networkFences.Items {
 		// Check if the resource is in the desired namespace
-		if fence.Namespace == cephCluster.Namespace {
-			if strings.Contains(fence.Name, rbdDriver) {
-				rbdCount++
-			} else if strings.Contains(fence.Name, cephfsDriver) {
-				cephFsCount++
-			}
+		if strings.Contains(fence.Name, rbdDriver) {
+			rbdCount++
+		} else if strings.Contains(fence.Name, cephfsDriver) {
+			cephFsCount++
 		}
 	}
 
@@ -431,10 +429,10 @@ func TestHandleNodeFailure(t *testing.T) {
 	err = c.handleNodeFailure(ctx, cephCluster, node)
 	assert.NoError(t, err)
 
-	err = c.client.Get(ctx, types.NamespacedName{Name: fenceResourceName(node.Name, rbdDriver), Namespace: cephCluster.Namespace}, networkFenceRbd)
+	err = c.client.Get(ctx, types.NamespacedName{Name: fenceResourceName(node.Name, rbdDriver, ns), Namespace: cephCluster.Namespace}, networkFenceRbd)
 	assert.Error(t, err, kerrors.IsNotFound(err))
 
-	err = c.client.Get(ctx, types.NamespacedName{Name: fenceResourceName(node.Name, cephfsDriver), Namespace: cephCluster.Namespace}, networkFenceCephFs)
+	err = c.client.Get(ctx, types.NamespacedName{Name: fenceResourceName(node.Name, cephfsDriver, ns), Namespace: cephCluster.Namespace}, networkFenceCephFs)
 	assert.Error(t, err, kerrors.IsNotFound(err))
 
 }
@@ -487,8 +485,8 @@ func TestConcatenateWatcherIp(t *testing.T) {
 }
 
 func TestFenceResourceName(t *testing.T) {
-	FenceName := fenceResourceName("fakenode", "rbd")
-	assert.Equal(t, FenceName, "fakenode-rbd")
+	FenceName := fenceResourceName("fakenode", "rbd", "rook-ceph")
+	assert.Equal(t, FenceName, "fakenode-rbd-rook-ceph")
 }
 
 func TestOnDeviceCMUpdate(t *testing.T) {

--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -161,7 +161,7 @@ func (r *ReconcileCSI) setParams(ver *version.Info) error {
 	}
 
 	CSIParam.EnableCSIAddonsSideCar = false
-	_, err = r.context.ApiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(r.opManagerContext, "csiaddonsnode.csiaddons.openshift.io", metav1.GetOptions{})
+	_, err = r.context.ApiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(r.opManagerContext, "csiaddonsnodes.csiaddons.openshift.io", metav1.GetOptions{})
 	if err == nil {
 		CSIParam.EnableCSIAddonsSideCar = true
 	}


### PR DESCRIPTION
since networkFence is a cluster-based resource so that we don't need the namespace and ownerReferences as it cause garbage-collector errors. Also, now we create the networkFence with clusteUID label so when doing cleanup we match the cephCluster uid and networkFence label clusterUID.

Signed-off-by: subhamkrai <srai@redhat.com>
(cherry picked from commit 5bff860380f34d1aa1ee9dceb9bcb2ed5d64da58)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
