### PR TITLE
Bug 2264553: mon: set mon pdb max unavailable as 2 in case of 5 or more mons

### DIFF
--- a/pkg/operator/ceph/cluster/mon/drain_test.go
+++ b/pkg/operator/ceph/cluster/mon/drain_test.go
@@ -102,7 +102,7 @@ func TestReconcileMonPDB(t *testing.T) {
 					},
 				},
 			},
-			expectedMaxUnAvailable: 1,
+			expectedMaxUnAvailable: 2,
 			errorExpected:          false,
 		},
 	}


### PR DESCRIPTION
If the spec.mon.count is 5 or more, then create
mon pdbs with maxUnavailable count as 2. We can
afford to have more than 1 mons down while
draining the nodes in this case.

Signed-off-by: sp98 <sapillai@redhat.com>
(cherry picked from commit a4866b4b066ec87c26cee0ba930338e8b5c467a4)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
