### PR TITLE
Added new rook bundle creation script

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -1,0 +1,13 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=rook-ceph-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+
+# Copy files to locations specified by labels.
+COPY build/csv/ceph /manifests/
+COPY build/bundle/annotations.yaml /metadata/

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,10 @@ gen-csv: export NO_OB_OBC_VOL_GEN=true
 gen-csv: csv-clean crds ## Generate a CSV file for OLM.
 	$(MAKE) -C images/ceph csv
 
+bundle:
+	@echo generate rook bundle
+	@build/bundle/gen-bundle.sh
+
 csv-clean: ## Remove existing OLM files.
 	@$(MAKE) -C images/ceph csv-clean
 

--- a/build/bundle/annotations.yaml
+++ b/build/bundle/annotations.yaml
@@ -1,0 +1,6 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: rook-ceph-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha

--- a/build/bundle/gen-bundle.sh
+++ b/build/bundle/gen-bundle.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+source "build/common.sh"
+
+# Use the available container management tool
+if [ -z "$DOCKERCMD" ]; then
+    DOCKERCMD=$(command -v docker || echo "")
+fi
+if [ -z "$DOCKERCMD" ]; then
+    DOCKERCMD=$(command -v podman || echo "")
+fi
+
+if [ -z "$DOCKERCMD" ]; then
+    echo -e '\033[1;31m' "podman or docker not found on system" '\033[0m'
+    exit 1
+fi
+
+${DOCKERCMD} build --platform="${GOOS}"/"${GOARCH}" --no-cache -t "$BUNDLE_IMAGE" -f Dockerfile.bundle .
+echo
+echo "Run '${DOCKERCMD} push ${BUNDLE_IMAGE}' to push operator bundle to image registry."

--- a/build/common.sh
+++ b/build/common.sh
@@ -24,6 +24,15 @@ scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export OUTPUT_DIR=${BUILD_ROOT}/_output
 export WORK_DIR=${BUILD_ROOT}/.work
 export CACHE_DIR=${BUILD_ROOT}/.cache
+export GOOS
+GOOS=$(go env GOOS)
+export GOARCH
+GOARCH=$(go env GOARCH)
+DEFAULT_CSV_VERSION="4.15.0"
+CSV_VERSION="${CSV_VERSION:-${DEFAULT_CSV_VERSION}}"
+export ROOK_IMAGE="docker.io/rook/ceph:v1.13.0.399.g9c0d795e2"
+DEFAULT_BUNDLE_IMAGE=rook/rook-ceph-operator-bundle:"${VERSION}"
+BUNDLE_IMAGE="${BUNDLE_IMAGE:-${DEFAULT_BUNDLE_IMAGE}}"
 
 function ver() {
     local full_ver maj min bug build

--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -201,7 +201,7 @@ metadata:
     operators.operatorframework.io/project_layout: unknown
     tectonic-visibility: ocs
     repository: https://github.com/red-hat-storage/rook
-    containerImage: '{{.RookOperatorImage}}'
+    containerImage: docker.io/rook/ceph:v1.13.0.399.g9c0d795e2
     externalClusterScript: |-
       IiIiCkNvcHlyaWdodCAyMDIwIFRoZSBSb29rIEF1dGhvcnMuIEFsbCByaWdodHMgcmVzZXJ2ZWQu
       CgpMaWNlbnNlZCB1bmRlciB0aGUgQXBhY2hlIExpY2Vuc2UsIFZlcnNpb24gMi4wICh0aGUgIkxp
@@ -1860,7 +1860,7 @@ metadata:
       OgogICAgICAgIHByaW50KGYiS2V5RXJyb3I6IHtrRXJyfSIpCiAgICBleGNlcHQgT1NFcnJvciBh
       cyBvc0VycjoKICAgICAgICBwcmludChmIkVycm9yIHdoaWxlIHRyeWluZyB0byBvdXRwdXQgdGhl
       IGRhdGE6IHtvc0Vycn0iKQogICAgZmluYWxseToKICAgICAgICByak9iai5zaHV0ZG93bigpCg==
-  name: rook-ceph.v{{.RookOperatorCsvVersion}}
+  name: rook-ceph-operator.v4.15.0
   namespace: placeholder
   relatedImages:
     - image: docker.io/rook/ceph:master
@@ -3034,7 +3034,7 @@ spec:
                             fieldPath: metadata.namespace
                       - name: ROOK_OBC_WATCH_OPERATOR_NAMESPACE
                         value: "true"
-                    image: {{.RookOperatorImage}}
+                    image: docker.io/rook/ceph:v1.13.0.399.g9c0d795e2
                     name: rook-ceph-operator
                     resources: {}
                     securityContext:
@@ -3374,5 +3374,5 @@ spec:
   provider:
     name: Provider Name
     url: https://your.domain
-  version: {{.RookOperatorCsvVersion}}
+  version: 4.15.0
   minKubeVersion: 1.16.0

--- a/build/csv/csv-gen.sh
+++ b/build/csv/csv-gen.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+source "../../build/common.sh"
+
 #############
 # VARIABLES #
 #############
@@ -13,7 +15,7 @@ YQ_CMD_DELETE=("$yq" delete -i)
 YQ_CMD_MERGE_OVERWRITE=("$yq" merge --inplace --overwrite --prettyPrint)
 YQ_CMD_MERGE=("$yq" merge --arrays=append --inplace)
 YQ_CMD_WRITE=("$yq" write --inplace -P)
-CSV_FILE_NAME="../../build/csv/ceph/$PLATFORM/manifests/rook-ceph.clusterserviceversion.yaml"
+CSV_FILE_NAME="../../build/csv/ceph/$PLATFORM/manifests/rook-ceph-operator.clusterserviceversion.yaml"
 CEPH_EXTERNAL_SCRIPT_FILE="../../deploy/examples/create-external-cluster-resources.py"
 ASSEMBLE_FILE_COMMON="../../deploy/olm/assemble/metadata-common.yaml"
 ASSEMBLE_FILE_OCP="../../deploy/olm/assemble/metadata-ocp.yaml"
@@ -23,7 +25,7 @@ ASSEMBLE_FILE_OCP="../../deploy/olm/assemble/metadata-ocp.yaml"
 #############
 
 function generate_csv() {
-    kubectl kustomize ../../deploy/examples/ | "$operator_sdk" generate bundle --package="rook-ceph" --output-dir="../../build/csv/ceph/$PLATFORM" --extra-service-accounts=rook-ceph-default,rook-csi-rbd-provisioner-sa,rook-csi-rbd-plugin-sa,rook-csi-cephfs-provisioner-sa,rook-csi-nfs-provisioner-sa,rook-csi-nfs-plugin-sa,rook-csi-cephfs-plugin-sa,rook-ceph-system,rook-ceph-rgw,rook-ceph-purge-osd,rook-ceph-osd,rook-ceph-mgr,rook-ceph-cmd-reporter
+    kubectl kustomize ../../deploy/examples/ | "$operator_sdk" generate bundle --package="rook-ceph-operator" --output-dir="../../build/csv/ceph/$PLATFORM" --extra-service-accounts=rook-ceph-default,rook-csi-rbd-provisioner-sa,rook-csi-rbd-plugin-sa,rook-csi-cephfs-provisioner-sa,rook-csi-nfs-provisioner-sa,rook-csi-nfs-plugin-sa,rook-csi-cephfs-plugin-sa,rook-ceph-system,rook-ceph-rgw,rook-ceph-purge-osd,rook-ceph-osd,rook-ceph-mgr,rook-ceph-cmd-reporter
 
     # cleanup to get the expected state before merging the real data from assembles
     "${YQ_CMD_DELETE[@]}" "$CSV_FILE_NAME" 'spec.icon[*]'
@@ -33,7 +35,7 @@ function generate_csv() {
 
     "${YQ_CMD_MERGE_OVERWRITE[@]}" "$CSV_FILE_NAME" "$ASSEMBLE_FILE_COMMON"
     "${YQ_CMD_WRITE[@]}" "$CSV_FILE_NAME" metadata.annotations.externalClusterScript "$(base64 <$CEPH_EXTERNAL_SCRIPT_FILE)"
-    "${YQ_CMD_WRITE[@]}" "$CSV_FILE_NAME" metadata.name "rook-ceph.v${VERSION}"
+    "${YQ_CMD_WRITE[@]}" "$CSV_FILE_NAME" metadata.name "rook-ceph-operator.v${CSV_VERSION}"
 
     "${YQ_CMD_MERGE[@]}" "$CSV_FILE_NAME" "$ASSEMBLE_FILE_OCP"
 
@@ -47,11 +49,11 @@ function generate_csv() {
         return
     fi
 
-    sed -i 's/image: rook\/ceph:.*/image: {{.RookOperatorImage}}/g' "$CSV_FILE_NAME"
-    sed -i 's/name: rook-ceph.v.*/name: rook-ceph.v{{.RookOperatorCsvVersion}}/g' "$CSV_FILE_NAME"
-    sed -i 's/version: 0.0.0/version: {{.RookOperatorCsvVersion}}/g' "$CSV_FILE_NAME"
+    sed -i "s|containerImage: rook/ceph:.*|containerImage: $ROOK_IMAGE|" "$CSV_FILE_NAME"
+    sed -i "s|image: rook/ceph:.*|image: $ROOK_IMAGE|" "$CSV_FILE_NAME"
+    sed -i "s/name: rook-ceph.v.*/name: rook-ceph-operator.v$CSV_VERSION/g" "$CSV_FILE_NAME"
+    sed -i "s/version: 0.0.0/version: $CSV_VERSION/g" "$CSV_FILE_NAME"
 
-    mv "$CSV_FILE_NAME" "../../build/csv/"
     mv "../../build/csv/ceph/$PLATFORM/manifests/"* "../../build/csv/ceph/"
     rm -rf "../../build/csv/ceph/$PLATFORM"
 }

--- a/deploy/olm/assemble/metadata-common.yaml
+++ b/deploy/olm/assemble/metadata-common.yaml
@@ -233,7 +233,7 @@ metadata:
   annotations:
     tectonic-visibility: ocs
     repository: https://github.com/red-hat-storage/rook
-    containerImage: "{{.RookOperatorImage}}"
+    containerImage: rook/ceph:master
     alm-examples: |-
       [
         {


### PR DESCRIPTION
- Added Dockerfile to create rook-ceph-operator-bundle under the rook repo.
- Updated the Makefile to have the 'bundle' command, that reference the 'gen-bundle.sh' script under `build/bundle`.
- Moved the rook csv under build/csv/ceph directory to keep all the manifests at one location for bundle creation

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [X] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
