### PR TITLE
BUG 2265514: csi: update CSIDriverOption params during saving cluster config

### DIFF
--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -20,7 +20,7 @@ ARG S5CMD_VERSION
 ARG S5CMD_ARCH
 
 # install 'ip' tool for Multus
-RUN dnf install -y --setopt=install_weak_deps=False iproute && dnf clean all
+RUN dnf install -y --repo baseos --setopt=install_weak_deps=False iproute && dnf clean all
 
 # Install the s5cmd package to interact with s3 gateway
 RUN curl --fail -sSL -o /s5cmd.tar.gz https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_${S5CMD_ARCH}.tar.gz && \

--- a/pkg/operator/ceph/csi/cluster_config_test.go
+++ b/pkg/operator/ceph/csi/cluster_config_test.go
@@ -38,6 +38,14 @@ func TestUpdateCsiClusterConfig(t *testing.T) {
 			RadosNamespace:       "rook-ceph-1",
 		},
 	}
+	csiClusterConfigEntryMountOptions := CsiClusterConfigEntry{
+		Namespace: "rook-ceph-1",
+		Monitors:  []string{"1.2.3.4:5000"},
+		CephFS: &CsiCephFSSpec{
+			KernelMountOptions: "ms_mode=crc",
+			FuseMountOptions:   "debug",
+		},
+	}
 	csiClusterConfigEntry2 := CsiClusterConfigEntry{
 		Namespace: "rook-ceph-2",
 		Monitors:  []string{"20.1.1.1:5000", "20.1.1.2:5000", "20.1.1.3:5000"},
@@ -70,6 +78,17 @@ func TestUpdateCsiClusterConfig(t *testing.T) {
 		assert.Contains(t, cc[0].Monitors, "1.2.3.4:5000")
 		assert.Contains(t, cc[0].Monitors, "10.11.12.13:5000")
 		assert.Equal(t, 2, len(cc[0].Monitors))
+	})
+
+	t.Run("add mount options to the current cluster", func(t *testing.T) {
+		configWithMountOptions, err := updateCsiClusterConfig(s, "rook-ceph-1", &csiClusterConfigEntryMountOptions)
+		assert.NoError(t, err)
+		cc, err := parseCsiClusterConfig(configWithMountOptions)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(cc))
+		assert.Equal(t, "rook-ceph-1", cc[0].ClusterID)
+		assert.Equal(t, csiClusterConfigEntryMountOptions.CephFS.KernelMountOptions, cc[0].CephFS.KernelMountOptions)
+		assert.Equal(t, csiClusterConfigEntryMountOptions.CephFS.FuseMountOptions, cc[0].CephFS.FuseMountOptions)
 	})
 
 	t.Run("add a 2nd cluster with 3 mons", func(t *testing.T) {
@@ -125,6 +144,19 @@ func TestUpdateCsiClusterConfig(t *testing.T) {
 		assert.Equal(t, "10.1.1.1:5000", cc[2].Monitors[0])
 		assert.Equal(t, 3, len(cc[2].Monitors))
 		assert.Equal(t, "my-group", cc[2].CephFS.SubvolumeGroup)
+
+	})
+
+	t.Run("update mount options in presence of subvolumegroup", func(t *testing.T) {
+		sMntOptionUpdate, err := updateCsiClusterConfig(s, "baba", &csiClusterConfigEntryMountOptions)
+		assert.NoError(t, err)
+		cc, err := parseCsiClusterConfig(sMntOptionUpdate)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(cc))
+		assert.Equal(t, "baba", cc[2].ClusterID)
+		assert.Equal(t, "my-group", cc[2].CephFS.SubvolumeGroup)
+		assert.Equal(t, csiClusterConfigEntryMountOptions.CephFS.KernelMountOptions, cc[2].CephFS.KernelMountOptions)
+		assert.Equal(t, csiClusterConfigEntryMountOptions.CephFS.FuseMountOptions, cc[2].CephFS.FuseMountOptions)
 
 	})
 


### PR DESCRIPTION
During cluster creation, csi config map was first filled with mon ips and without CSIDriverOptions.
This commit makes sure CSIDriverOptions are added at the begining when the entry is first created.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit 330f604cca1384b763bce629626b75fce6f73bd4)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
