### PR TITLE
build: add rbac for default sa

### DIFF
--- a/deploy/charts/library/templates/_cluster-role.tpl
+++ b/deploy/charts/library/templates/_cluster-role.tpl
@@ -148,4 +148,14 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "update", "delete", "list"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-default
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+rules:
+  - apiGroups: [""]
+    resources: [""]
+    verbs: [""]
 {{- end }}

--- a/deploy/charts/library/templates/_cluster-rolebinding.tpl
+++ b/deploy/charts/library/templates/_cluster-rolebinding.tpl
@@ -105,4 +105,18 @@ subjects:
   - kind: ServiceAccount
     name: rook-ceph-purge-osd
     namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-default
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-default
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-default
+    namespace: {{ .Release.Namespace }} # namespace:cluster
 {{- end }}

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -790,6 +790,16 @@ rules:
       - update
       - delete
 ---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-default
+  namespace: rook-ceph # namespace:cluster
+rules:
+  - apiGroups: [""]
+    resources: [""]
+    verbs: [""]
+---
 # Aspects of ceph-mgr that operate within the cluster's namespace
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1050,6 +1060,20 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-cmd-reporter
+    namespace: rook-ceph # namespace:cluster
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-default
+  namespace: rook-ceph # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-default
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-default
     namespace: rook-ceph # namespace:cluster
 ---
 # Allow the ceph mgr to access resources scoped to the CephCluster namespace necessary for mgr modules


### PR DESCRIPTION
rook csv doesnt contain the default
service account

recently we added default sa for most
of the ceph daemons but it didnt have the
rbacs, so added the rbacs to it
so rook csv can generate default sa

Signed-off-by: parth-gr <partharora1010@gmail.com>
(cherry picked from commit d27cfbde1fe1355b6f01c096c4f8c56d20c9b701)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
