### PR TITLE
ci: push downstream image to ocs/dev

### DIFF
--- a/.github/workflows/push-build-downstream.yaml
+++ b/.github/workflows/push-build-downstream.yaml
@@ -1,0 +1,54 @@
+name: Push Image Build Downstream
+on:
+  push:
+    branches:
+      - master
+      - release-*
+
+defaults:
+  run:
+    # reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+
+permissions:
+  contents: read
+
+jobs:
+  push-image-to-container-registry:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'red-hat-storage/rook'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+
+        # docker/setup-qemu action installs QEMU static binaries, which are used to run builders for architectures other than the host.
+      - name: set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_OCS_DEV_ROBOT_USER }}
+          password: ${{ secrets.QUAY_OCS_DEV_ROBOT_PASSWORD }}
+
+      # creating custom env var
+      - name: set env
+        run: |
+          echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "GITHUB_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+
+      - name: build and release
+        env:
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+          GITHUB_SHA: $ {{ env.GITHUB_SHA }}
+        run: |
+          tests/scripts/build-release-downstream.sh

--- a/tests/scripts/build-release-downstream.sh
+++ b/tests/scripts/build-release-downstream.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -ex
+
+MAKE='make --debug=v --output-sync'
+
+# build and push rook image
+$MAKE build BUILD_REGISTRY=local
+build_image="local/ceph-amd64:latest"
+git_hash=$(git rev-parse --short "${GITHUB_SHA}")
+tag_image=quay.io/ocs-dev/rook-ceph:v${BRANCH_NAME}-$git_hash
+docker tag "$build_image" "$tag_image"
+docker push "$tag_image"
+
+# build and push rook bundle
+export ROOK_IMAGE=$tag_image
+make gen-csv
+DOCKERCMD=podman BUNDLE_IMAGE=quay.io/ocs-dev/rook-ceph-operator-bundle:${BRANCH_NAME}-$git_hash make bundle
+podman push quay.io/ocs-dev/rook-ceph-operator-bundle:"${BRANCH_NAME}"-"$git_hash"


### PR DESCRIPTION
we have some changes related to downstream
so we need to have a separate downstream image
so the ocs operator ci can make use of it

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
