### PR TITLE
build: add new env value ref for operator

### DIFF
--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -3000,6 +3000,16 @@ spec:
                           configMapKeyRef:
                             key: ROOK_CSI_ENABLE_NFS
                             name: ocs-operator-config
+                      - name: ROOK_CSI_ENABLE_CEPHFS
+                        valueFrom:
+                          configMapKeyRef:
+                            key: ROOK_CSI_ENABLE_CEPHFS
+                            name: ocs-operator-config
+                      - name: ROOK_CSI_ENABLE_RBD
+                        valueFrom:
+                          configMapKeyRef:
+                            key: ROOK_CSI_ENABLE_RBD
+                            name: ocs-operator-config
                       - name: CSI_PROVISIONER_TOLERATIONS
                         value: |2-
 

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -749,6 +749,16 @@ spec:
                 configMapKeyRef:
                   key: ROOK_CSI_ENABLE_NFS
                   name: ocs-operator-config
+            - name: ROOK_CSI_ENABLE_CEPHFS
+              valueFrom:
+                configMapKeyRef:
+                  key: ROOK_CSI_ENABLE_CEPHFS
+                  name: ocs-operator-config
+            - name: ROOK_CSI_ENABLE_RBD
+              valueFrom:
+                configMapKeyRef:
+                  key: ROOK_CSI_ENABLE_RBD
+                  name: ocs-operator-config
             - name: CSI_PROVISIONER_TOLERATIONS
               value: |2-
 


### PR DESCRIPTION
Added the new stanza to `deploy/examples/operator-openshift.yaml` and ran `make gen-csv`

We are going to update the configmap from ocs-operator to disable the CSI during runtime and these values are required for rook to realize the update.