### PR TITLE
build: add new env value ref for operator

### DIFF
--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -3005,15 +3005,10 @@ spec:
                           configMapKeyRef:
                             key: ROOK_CSI_ENABLE_NFS
                             name: ocs-operator-config
-                      - name: ROOK_CSI_ENABLE_CEPHFS
+                      - name: ROOK_CSI_DISABLE_DRIVER
                         valueFrom:
                           configMapKeyRef:
-                            key: ROOK_CSI_ENABLE_CEPHFS
-                            name: ocs-operator-config
-                      - name: ROOK_CSI_ENABLE_RBD
-                        valueFrom:
-                          configMapKeyRef:
-                            key: ROOK_CSI_ENABLE_RBD
+                            key: ROOK_CSI_DISABLE_DRIVER
                             name: ocs-operator-config
                       - name: CSI_PROVISIONER_TOLERATIONS
                         value: |2-

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -761,15 +761,10 @@ spec:
                 configMapKeyRef:
                   key: ROOK_CSI_ENABLE_NFS
                   name: ocs-operator-config
-            - name: ROOK_CSI_ENABLE_CEPHFS
+            - name: ROOK_CSI_DISABLE_DRIVER
               valueFrom:
                 configMapKeyRef:
-                  key: ROOK_CSI_ENABLE_CEPHFS
-                  name: ocs-operator-config
-            - name: ROOK_CSI_ENABLE_RBD
-              valueFrom:
-                configMapKeyRef:
-                  key: ROOK_CSI_ENABLE_RBD
+                  key: ROOK_CSI_DISABLE_DRIVER
                   name: ocs-operator-config
             - name: CSI_PROVISIONER_TOLERATIONS
               value: |2-


### PR DESCRIPTION
Add ability to read disable csi driver value from env set in ocs-operator configmap.

Depends on rook/rook#13966, #601
