### PR TITLE
csi: add a new flag to disable csi driver

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -80,6 +80,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.csiRBDPluginVolume` | The volume of the CephCSI RBD plugin DaemonSet | `nil` |
 | `csi.csiRBDPluginVolumeMount` | The volume mounts of the CephCSI RBD plugin DaemonSet | `nil` |
 | `csi.csiRBDProvisionerResource` | CEPH CSI RBD provisioner resource requirement list csi-omap-generator resources will be applied only if `enableOMAPGenerator` is set to `true` | see values.yaml |
+| `csi.disableCsiDriver` | Disable the CSI driver. | `"false"` |
 | `csi.disableHolderPods` | Deprecation note: Rook uses "holder" pods to allow CSI to connect to the multus public network without needing hosts to the network. Holder pods are being deprecated. See issue for details: https://github.com/rook/rook/issues/13055. New Rook deployments should set this to "true". | `true` |
 | `csi.enableCSIEncryption` | Enable Ceph CSI PVC encryption support | `false` |
 | `csi.enableCSIHostNetwork` | Enable host networking for CSI CephFS and RBD nodeplugins. This may be necessary in some network configurations where the SDN does not provide access to an external cluster or there is significant drop in read/write performance | `true` |

--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -3005,15 +3005,10 @@ spec:
                           configMapKeyRef:
                             key: ROOK_CSI_ENABLE_NFS
                             name: ocs-operator-config
-                      - name: ROOK_CSI_ENABLE_CEPHFS
+                      - name: ROOK_CSI_DISABLE_DRIVER
                         valueFrom:
                           configMapKeyRef:
-                            key: ROOK_CSI_ENABLE_CEPHFS
-                            name: ocs-operator-config
-                      - name: ROOK_CSI_ENABLE_RBD
-                        valueFrom:
-                          configMapKeyRef:
-                            key: ROOK_CSI_ENABLE_RBD
+                            key: ROOK_CSI_DISABLE_DRIVER
                             name: ocs-operator-config
                       - name: CSI_PROVISIONER_TOLERATIONS
                         value: |2-

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
 {{- if .Values.csi }}
   ROOK_CSI_ENABLE_RBD: {{ .Values.csi.enableRbdDriver | quote }}
   ROOK_CSI_ENABLE_CEPHFS: {{ .Values.csi.enableCephfsDriver | quote }}
+  ROOK_CSI_DISABLE_DRIVER: {{ .Values.csi.disableCsiDriver | quote }}
   CSI_ENABLE_CEPHFS_SNAPSHOTTER: {{ .Values.csi.enableCephfsSnapshotter | quote }}
   CSI_ENABLE_NFS_SNAPSHOTTER: {{ .Values.csi.enableNFSSnapshotter | quote }}
   CSI_ENABLE_RBD_SNAPSHOTTER: {{ .Values.csi.enableRBDSnapshotter | quote }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -81,6 +81,9 @@ csi:
   enableRbdDriver: true
   # -- Enable Ceph CSI CephFS driver
   enableCephfsDriver: true
+  # -- Disable the CSI driver.
+  disableCsiDriver: "false"
+
   # -- Enable host networking for CSI CephFS and RBD nodeplugins. This may be necessary
   # in some network configurations where the SDN does not provide access to an external cluster or
   # there is significant drop in read/write performance

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -121,6 +121,8 @@ data:
   ROOK_CSI_ENABLE_RBD: "true"
   # Enable the CSI NFS driver. To start another version of the CSI driver, see image properties below.
   ROOK_CSI_ENABLE_NFS: "false"
+  # Disable the CSI driver.
+  ROOK_CSI_DISABLE_DRIVER: "false"
 
   # Set to true to enable Ceph CSI pvc encryption support.
   CSI_ENABLE_ENCRYPTION: "false"

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -763,15 +763,10 @@ spec:
                 configMapKeyRef:
                   key: ROOK_CSI_ENABLE_NFS
                   name: ocs-operator-config
-            - name: ROOK_CSI_ENABLE_CEPHFS
+            - name: ROOK_CSI_DISABLE_DRIVER
               valueFrom:
                 configMapKeyRef:
-                  key: ROOK_CSI_ENABLE_CEPHFS
-                  name: ocs-operator-config
-            - name: ROOK_CSI_ENABLE_RBD
-              valueFrom:
-                configMapKeyRef:
-                  key: ROOK_CSI_ENABLE_RBD
+                  key: ROOK_CSI_DISABLE_DRIVER
                   name: ocs-operator-config
             - name: CSI_PROVISIONER_TOLERATIONS
               value: |2-

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -35,6 +35,8 @@ data:
   ROOK_CSI_ENABLE_RBD: "true"
   # Enable the CSI NFS driver. To start another version of the CSI driver, see image properties below.
   ROOK_CSI_ENABLE_NFS: "false"
+  # Disable the CSI driver.
+  ROOK_CSI_DISABLE_DRIVER: "false"
 
   # Set to true to enable Ceph CSI pvc encryption support.
   CSI_ENABLE_ENCRYPTION: "false"


### PR DESCRIPTION
added a new flag ROOK_CSI_DISABLE_DRIVER
to disable csi controller.

Signed-off-by: parth-gr <partharora1010@gmail.com>
(cherry picked from commit a72e02945978a2a115207d6ea40e14223d8af4a6)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
