### PR TITLE
Fix provider name in rook csv

### DIFF
--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -3382,8 +3382,8 @@ spec:
       email: ocs-support@redhat.com
   maturity: alpha
   provider:
-    name: Provider Name
-    url: https://your.domain
+    name: Red Hat
+    url: https://www.redhat.com
   version: 4.15.0
   minKubeVersion: 1.16.0
   relatedImages:

--- a/deploy/olm/assemble/metadata-common.yaml
+++ b/deploy/olm/assemble/metadata-common.yaml
@@ -212,6 +212,9 @@ spec:
       "block storage",
       "shared filesystem",
     ]
+  provider:
+    name: Red Hat
+    url: https://www.redhat.com
   minKubeVersion: 1.16.0
   links:
     - name: Source Code

--- a/deploy/olm/assemble/metadata-ocp.yaml
+++ b/deploy/olm/assemble/metadata-ocp.yaml
@@ -15,5 +15,3 @@ spec:
   maintainers:
     - name: Red Hat Support
       email: ocs-support@redhat.com
-  provider:
-    name: Red Hat


### PR DESCRIPTION
Fix provider name in rook csv i.e, use `Red Hat` for the name and url field.
Also, moved the `provider` field to `metadata-common.yaml` file so that defaults are overriden during the csv generation.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
