### PR TITLE
operator: load cluster owner info in LoadClusterInfo

### DIFF
--- a/pkg/operator/ceph/controller/cluster_info.go
+++ b/pkg/operator/ceph/controller/cluster_info.go
@@ -141,6 +141,9 @@ func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, context context.
 		} else {
 			return nil, maxMonID, monMapping, errors.New("failed to find either the cluster admin key or the username")
 		}
+		if len(secrets.OwnerReferences) > 0 {
+			clusterInfo.OwnerInfo = k8sutil.NewOwnerInfoWithOwnerRef(&secrets.GetOwnerReferences()[0], namespace)
+		}
 		logger.Debugf("found existing monitor secrets for cluster %s", clusterInfo.Namespace)
 	}
 


### PR DESCRIPTION
The CreateOrLoadClusterInfo (and therefore LoadClusterInfo) methods were not loading the ClusterInfo.OwnerInfo. This should help future CRD controllers get the full ClusterInfo struct without having missing information. Current controllers that need ClusterInfo fill the field themselves.

During testing, I observed one corner case where an upgraded cluster was missing the `rook-ceph-csi-config` configmap. The cluster had a CephFilesystemSubVolumeGroup resource created, and the reconcile for that resource was attempting to create the missing CSI configmap and failing with a nil pointer exception due to the missing OwnerInfo field in ClusterInfo. This cluster condition hasn't been reproduced in healthy environments, and it is unknown how the CSI configmap came to be missing. However, the case did expose the missing loaded info as a potential for causing nil pointer exceptions during corner cases when code is otherwise correct.

Signed-off-by: Blaine Gardner <blaine.gardner@ibm.com>
(cherry picked from commit bd9447ea4c52ae05f96aa46c278d3b3cd3f829c2)
Signed-off-by: sp98 <sapillai@redhat.com>

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
