### PR TITLE
BUG 2275886: Fix OwnerReferences on CSI config map

### DIFF
--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -108,12 +108,6 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 		}
 	}
 
-	// Create CSI config map
-	err = csi.CreateCsiConfigMap(c.OpManagerCtx, c.namespacedName.Namespace, c.context.Clientset, cluster.ownerInfo)
-	if err != nil {
-		return errors.Wrap(err, "failed to create csi config map")
-	}
-
 	// update the msgr2 flag
 	for _, m := range cluster.ClusterInfo.Monitors {
 		// m.Endpoint=10.1.115.104:3300

--- a/pkg/operator/ceph/controller/cluster_info.go
+++ b/pkg/operator/ceph/controller/cluster_info.go
@@ -141,6 +141,9 @@ func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, context context.
 		} else {
 			return nil, maxMonID, monMapping, errors.New("failed to find either the cluster admin key or the username")
 		}
+		if len(secrets.OwnerReferences) > 0 {
+			clusterInfo.OwnerInfo = k8sutil.NewOwnerInfoWithOwnerRef(&secrets.GetOwnerReferences()[0], namespace)
+		}
 		logger.Debugf("found existing monitor secrets for cluster %s", clusterInfo.Namespace)
 	}
 

--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -254,9 +254,47 @@ func CreateCsiConfigMap(ctx context.Context, namespace string, clientset kuberne
 		if !k8serrors.IsAlreadyExists(err) {
 			return errors.Wrapf(err, "failed to create initial csi config map %q (in %q)", configMap.Name, namespace)
 		}
+		// CM already exists; update owner refs to it if needed
+		// this corrects issues where the csi config map was sometimes created with CephCluster
+		// owner ref, which would result in the cm being deleted if that cluster was deleted
+		if err := updateCsiConfigMapOwnerRefs(ctx, namespace, clientset, ownerInfo); err != nil {
+			return errors.Wrapf(err, "failed to ensure csi config map %q (in %q) owner references", configMap.Name, namespace)
+		}
 	}
 
 	logger.Infof("successfully created csi config map %q", configMap.Name)
+	return nil
+}
+
+// check the owner references on the csi config map, and fix incorrect references if needed
+func updateCsiConfigMapOwnerRefs(ctx context.Context, namespace string, clientset kubernetes.Interface, expectedOwnerInfo *k8sutil.OwnerInfo) error {
+	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, ConfigName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch csi config map %q (in %q) which already exists", ConfigName, namespace)
+	}
+
+	existingOwners := cm.GetOwnerReferences()
+	var currentOwner *metav1.OwnerReference = nil
+	if len(existingOwners) == 1 {
+		currentOwner = &existingOwners[0] // currentOwner is nil unless there is exactly one owner on the cm
+	}
+	// if there is exactly one owner, and it is correct --> no fix needed
+	if currentOwner != nil && (currentOwner.UID == expectedOwnerInfo.GetUID()) {
+		logger.Debugf("csi config map %q (in %q) has the expected owner; owner id: %q", ConfigName, namespace, currentOwner.UID)
+		return nil
+	}
+
+	// must fix owner refs
+	logger.Infof("updating csi configmap %q (in %q) owner info", ConfigName, namespace)
+	cm.OwnerReferences = []metav1.OwnerReference{}
+	if err := expectedOwnerInfo.SetControllerReference(cm); err != nil {
+		return errors.Wrapf(err, "failed to set updated owner reference on csi config map %q (in %q)", ConfigName, namespace)
+	}
+	_, err = clientset.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to update csi config map %q (in %q) to update its owner reference", ConfigName, namespace)
+	}
+
 	return nil
 }
 

--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -292,10 +292,7 @@ func SaveClusterConfig(clientset kubernetes.Interface, clusterNamespace string, 
 	configMap, err := clientset.CoreV1().ConfigMaps(csiNamespace).Get(clusterInfo.Context, ConfigName, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			err = CreateCsiConfigMap(clusterInfo.Context, csiNamespace, clientset, clusterInfo.OwnerInfo)
-			if err != nil {
-				return errors.Wrap(err, "failed creating csi config map")
-			}
+			return errors.Wrap(err, "waiting for CSI config map to be created")
 		}
 		return errors.Wrap(err, "failed to fetch current csi config map")
 	}

--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -144,7 +144,13 @@ func (info *OwnerInfo) SetControllerReference(object metav1.Object) error {
 
 // GetUID gets the UID of the owner
 func (info *OwnerInfo) GetUID() types.UID {
-	return info.owner.GetUID()
+	if info.owner != nil {
+		return info.owner.GetUID()
+	}
+	if info.ownerRef != nil {
+		return info.ownerRef.UID
+	}
+	return types.UID("")
 }
 
 func MergeResourceRequirements(first, second v1.ResourceRequirements) v1.ResourceRequirements {


### PR DESCRIPTION
This backport comprises 3 commits that address the BZ on multiple fronts.

Commit 2 (below) is the root cause fix. This fix was developed upon noticing that the bug was expressed when non-CSI controllers attempted to update the `rook-ceph-csi-config` configmap before it was created/initialized. On top of that, those non-CSI controllers were using an incorrect OwnerReference to init the configmap. With this change, the `rook-ceph-csi-config` configmap is only created by the main CSI controller, which does so with the correct owner reference. All other controllers will now wait for the configmap to exist before continuing. 

Commit 1 (below) is a fix that ensures any existing, brownfield ODF clusters are not affected by the "incorrect OwnerReference" issue mentioned above. This commit edits any existing CSI config maps to ensure they have the correct owner reference. Without this fix, users who have both internal and external mode ODF clusters are at risk of having the CSI configmap deleted if one of their CephClusters is deleted and the other remains running. External mode ODF clusters are particularly at risk, and I observed one non-external cluster that had incorrect owner info on the configmap as well. This is an uncommon user case, but it is an avoidable risk.

Commit 3 (below) is a fix that prevents nil pointer exceptions related to internal use of `LoadClusterInfo().OwnerInfo`. This fix is not required with the inclusion of the commits above; however, this fixes the surface-level cause of the nil pointer exception described in the BZ. It will therefore fix any currently undetected nil pointer errors (potential race conditions) similar to those observed by the BZ, and is a valuable commit to include "just in case" either of the commits above leave room for the error to persist.


Commits:

1. csi: ensure correct csi config map owner during creation
    
    In the primary CSI reconcile, ensure the CSI config map
    (`rook-ceph-csi-config`) has the correct owner info.
    
    This corrects any pre-existing config maps that might have incorrect
    owner info, which has observed to include references to CephClusters.
    The config map should only have a single reference, and it should refer
    to the operator deployment.
    
    If any existing Rook clusters have a CSI config map which has a
    CephCluster as an owner, this change will ensure that the config map is
    not deleted when the CephCluster is deleted. This is especially
    important for any environments with multiple CephClusters installed.


2. csi: only create CSI config configmap in CSI reconciler
    
    There have been some issues with non-CSI Rook controllers that are
    creating the CSI config configmap (`rook-ceph-csi-config`). This causes
    problems with the K8s OwnerReference. The primary CSI reconciler
    (controller) creates the configmap with the correct owner reference,
    which is supposed to be the operator deployment.
    
    Other instances were creating the configmap with owner references set to
    the CephCluster. This is a minor bug, but it can result in this
    configmap being deleted along with the first CephCluster that initially
    created it.
    
    To fix this issue, remove all instances of `CreateCsiConfigMap()` except
    the single usage which the CSI reconcile uses to initially create the
    configmap. Other controllers that might have attempted to create this
    configmap previously will return an error indicating that it is waiting
    for the configmap to be created.


3. operator: load cluster owner info in LoadClusterInfo
    
    The CreateOrLoadClusterInfo (and therefore LoadClusterInfo) methods were
    not loading the ClusterInfo.OwnerInfo. This should help future CRD
    controllers get the full ClusterInfo struct without having missing
    information. Current controllers that need ClusterInfo fill the field
    themselves.
    
    During testing, I observed one corner case where an upgraded cluster was
    missing the `rook-ceph-csi-config` configmap. The cluster had a
    CephFilesystemSubVolumeGroup resource created, and the reconcile for
    that resource was attempting to create the missing CSI configmap and
    failing with a nil pointer exception due to the missing OwnerInfo field
    in ClusterInfo. This cluster condition hasn't been reproduced in healthy
    environments, and it is unknown how the CSI configmap came to be
    missing. However, the case did expose the missing loaded info as a
    potential for causing nil pointer exceptions during corner cases when
    code is otherwise correct.


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
