### PR TITLE
Bug 2276591: csi: create csi configmap if csi controller is disabled

### DIFF
--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -260,9 +260,10 @@ func CreateCsiConfigMap(ctx context.Context, namespace string, clientset kuberne
 		if err := updateCsiConfigMapOwnerRefs(ctx, namespace, clientset, ownerInfo); err != nil {
 			return errors.Wrapf(err, "failed to ensure csi config map %q (in %q) owner references", configMap.Name, namespace)
 		}
+	} else {
+		logger.Infof("successfully created csi config map %q", configMap.Name)
 	}
 
-	logger.Infof("successfully created csi config map %q", configMap.Name)
 	return nil
 }
 


### PR DESCRIPTION
Creating a cluster never succeeds if CSI driver is disabled So to fix that we need to always create the csi configmap

closes: https://github.com/rook/rook/issues/14123

Signed-off-by: parth-gr <partharora1010@gmail.com>
(cherry picked from commit 47ed6a863268940f90e3701de6a77535a2a60147) (cherry picked from commit 91292df78b5a419365101265bf53ac32709cd7c4)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
