### PR TITLE
Bug 2266621: mon: fix mon scaledown when mons are portable

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -450,6 +450,7 @@ func (c *Cluster) determineExtraMonToRemove() string {
 	for _, mon := range mons {
 		if mon.NodeName == "" {
 			logger.Debugf("mon %q is not scheduled to a specific host", mon.DaemonName)
+			arbitraryMon = mon.DaemonName
 			continue
 		}
 		// Check if there are multiple mons on the node


### PR DESCRIPTION
in case of portable mons, mon scaledown was skipped with below code
```
if mon.NodeName == "" {
			logger.Debugf("mon %q is not scheduled to a specific host", mon.DaemonName)
			continue
		}
```
which skips mon removal if mon nodeName is empty
but if mons are scale down in case of portable mons in that case also we want to remove extra mons to match the cephCluster configuration.

Signed-off-by: subhamkrai <srai@redhat.com>
(cherry picked from commit d23a8433ed49d26ca39ea2649d14b4e288ccc720) (cherry picked from commit 3af95231e2dcbbc46d265bd151da63f4878065dc)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
