### PR TITLE
Bug 2269099: osd: limit storageClassDeviceSets to 63 chars

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-         go-version: "1.22.2"
+         go-version: "1.22"
          check-latest: true
       - name: govulncheck
         uses: golang/govulncheck-action@v1

--- a/build/csv/ceph/ceph.rook.io_cephclusters.yaml
+++ b/build/csv/ceph/ceph.rook.io_cephclusters.yaml
@@ -1717,6 +1717,7 @@ spec:
                         encrypted:
                           type: boolean
                         name:
+                          maxLength: 40
                           type: string
                         placement:
                           nullable: true

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -3512,6 +3512,7 @@ spec:
                             type: boolean
                           name:
                             description: Name is a unique identifier for the set
+                            maxLength: 40
                             type: string
                           placement:
                             nullable: true

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -3510,6 +3510,7 @@ spec:
                             type: boolean
                           name:
                             description: Name is a unique identifier for the set
+                            maxLength: 40
                             type: string
                           placement:
                             nullable: true

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2937,6 +2937,7 @@ type PriorityClassNamesSpec map[KeyType]string
 // +nullable
 type StorageClassDeviceSet struct {
 	// Name is a unique identifier for the set
+	// +kubebuilder:validation:MaxLength=40
 	Name string `json:"name"`
 	// Count is the number of devices in this set
 	// +kubebuilder:validation:Minimum=1

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -205,16 +205,20 @@ func (c *Cluster) createDeviceSetPVC(existingPVCs map[string]*v1.PersistentVolum
 	// old labels and PVC ID for backward compatibility
 	pvcID := legacyDeviceSetPVCID(deviceSetName, setIndex)
 
+	var err error
 	// check for the existence of the pvc
 	existingPVC, ok := existingPVCs[pvcID]
 	if !ok {
 		// The old name of the PVC didn't exist, now try the new PVC name and label
-		pvcID = deviceSetPVCID(deviceSetName, pvcTemplate.GetName(), setIndex)
+		pvcID, err = deviceSetPVCID(deviceSetName, pvcTemplate.GetName(), setIndex)
+		if err != nil {
+			return nil, err
+		}
 		existingPVC = existingPVCs[pvcID]
 	}
 
 	pvc := makeDeviceSetPVC(deviceSetName, pvcID, setIndex, pvcTemplate, c.clusterInfo.Namespace, createValidImageVersionLabel(c.spec.CephVersion.Image), createValidImageVersionLabel(c.rookVersion))
-	err := c.clusterInfo.OwnerInfo.SetControllerReference(pvc)
+	err = c.clusterInfo.OwnerInfo.SetControllerReference(pvc)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to set owner reference to osd pvc %q", pvc.Name)
 	}
@@ -291,10 +295,14 @@ func legacyDeviceSetPVCID(deviceSetName string, setIndex int) string {
 
 // This is the new function that generates the labels
 // It includes the pvcTemplateName in it
-func deviceSetPVCID(deviceSetName, pvcTemplateName string, setIndex int) string {
+func deviceSetPVCID(deviceSetName, pvcTemplateName string, setIndex int) (string, error) {
 	cleanName := strings.Replace(pvcTemplateName, " ", "-", -1)
 	deviceSetName = strings.Replace(deviceSetName, ".", "-", -1)
-	return fmt.Sprintf("%s-%s-%d", deviceSetName, cleanName, setIndex)
+	pvcID := fmt.Sprintf("%s-%s-%d", deviceSetName, cleanName, setIndex)
+	if len(pvcID) > 62 {
+		return "", fmt.Errorf("the OSD PVC name requested is %q (length %d) is too long and must be less than 63 characters, shorten either the storageClassDeviceSet name or the storage class name", pvcID, len(pvcID))
+	}
+	return pvcID, nil
 }
 
 func createValidImageVersionLabel(image string) string {

--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -280,16 +280,20 @@ func TestPrepareDeviceSetsWithCrushParams(t *testing.T) {
 }
 
 func TestPVCName(t *testing.T) {
-	id := deviceSetPVCID("mydeviceset", "a", 0)
-	assert.Equal(t, "mydeviceset-a-0", id)
+	id, err := deviceSetPVCID("mydeviceset-making-the-length-of-pvc-id-greater-than-the-limit-63", "a", 0)
+	assert.Error(t, err)
+	assert.Equal(t, "", id)
 
-	id = deviceSetPVCID("mydeviceset", "a", 10)
+	id, err = deviceSetPVCID("mydeviceset", "a", 10)
+	assert.NoError(t, err)
 	assert.Equal(t, "mydeviceset-a-10", id)
 
-	id = deviceSetPVCID("device-set", "a", 10)
+	id, err = deviceSetPVCID("device-set", "a", 10)
+	assert.NoError(t, err)
 	assert.Equal(t, "device-set-a-10", id)
 
-	id = deviceSetPVCID("device.set.with.dots", "b", 10)
+	id, err = deviceSetPVCID("device.set.with.dots", "b", 10)
+	assert.NoError(t, err)
 	assert.Equal(t, "device-set-with-dots-b-10", id)
 }
 


### PR DESCRIPTION
there are some cases where storageClassDeviceSets length are more 63 chars and osd provisioned failed due to this. with error
```
 failed to run osd provisioning job for PVC "ocs-deviceset-*-local-volume-storageclass-0-data-*": Job.batch "rook-ceph-osd-prepare-*" is invalid: [spec.template.spec.volumes[10].name: Invalid value: "ocs-deviceset-*-local-volume-storageclass-0-data-*": must be no more than 63 characters, spec.template.spec.containers[0].volumeMounts[9].name: Not found: "ocs-deviceset-*-local-volume-storageclass-0-data-*",
```

Using x-validator to limit the maxLength to the deviceClassSet.Name to 40 chars and adding code check that overall pvc name should be less than 63 chars.

Signed-off-by: subhamkrai <srai@redhat.com>
(cherry picked from commit 6f5cc9b01dd78924dc6bb8cff1f7215e6286aa0c) (cherry picked from commit 578f582c34879b8e450607db5c6bd77fe162f66d)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
