### PR TITLE
Bug 2274757: osd: Add cephcluster status for legacy osds to replace

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -4073,6 +4073,16 @@ OSDStatus
 <td>
 </td>
 </tr>
+<tr>
+<td>
+<code>deprecatedOSDs</code><br/>
+<em>
+map[string][]int
+</em>
+</td>
+<td>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.CephVersionSpec">CephVersionSpec

--- a/build/csv/ceph/ceph.rook.io_cephclusters.yaml
+++ b/build/csv/ceph/ceph.rook.io_cephclusters.yaml
@@ -3065,6 +3065,12 @@ spec:
                 type: string
               storage:
                 properties:
+                  deprecatedOSDs:
+                    additionalProperties:
+                      items:
+                        type: integer
+                      type: array
+                    type: object
                   deviceClasses:
                     items:
                       properties:

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -5148,6 +5148,12 @@ spec:
                 storage:
                   description: CephStorage represents flavors of Ceph Cluster Storage
                   properties:
+                    deprecatedOSDs:
+                      additionalProperties:
+                        items:
+                          type: integer
+                        type: array
+                      type: object
                     deviceClasses:
                       items:
                         description: DeviceClasses represents device classes of a Ceph Cluster

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -5146,6 +5146,12 @@ spec:
                 storage:
                   description: CephStorage represents flavors of Ceph Cluster Storage
                   properties:
+                    deprecatedOSDs:
+                      additionalProperties:
+                        items:
+                          type: integer
+                        type: array
+                      type: object
                     deviceClasses:
                       items:
                         description: DeviceClasses represents device classes of a Ceph Cluster

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -473,8 +473,9 @@ type Capacity struct {
 
 // CephStorage represents flavors of Ceph Cluster Storage
 type CephStorage struct {
-	DeviceClasses []DeviceClasses `json:"deviceClasses,omitempty"`
-	OSD           OSDStatus       `json:"osd,omitempty"`
+	DeviceClasses  []DeviceClasses  `json:"deviceClasses,omitempty"`
+	OSD            OSDStatus        `json:"osd,omitempty"`
+	DeprecatedOSDs map[string][]int `json:"deprecatedOSDs,omitempty"`
 }
 
 // DeviceClasses represents device classes of a Ceph Cluster

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -77,14 +77,15 @@ const (
 
 // Cluster keeps track of the OSDs
 type Cluster struct {
-	context      *clusterd.Context
-	clusterInfo  *cephclient.ClusterInfo
-	rookVersion  string
-	spec         cephv1.ClusterSpec
-	ValidStorage cephv1.StorageScopeSpec // valid subset of `Storage`, computed at runtime
-	kv           *k8sutil.ConfigMapKVStore
-	deviceSets   []deviceSet
-	replaceOSD   *OSDReplaceInfo
+	context        *clusterd.Context
+	clusterInfo    *cephclient.ClusterInfo
+	rookVersion    string
+	spec           cephv1.ClusterSpec
+	ValidStorage   cephv1.StorageScopeSpec // valid subset of `Storage`, computed at runtime
+	kv             *k8sutil.ConfigMapKVStore
+	deviceSets     []deviceSet
+	replaceOSD     *OSDReplaceInfo
+	deprecatedOSDs map[string][]int
 }
 
 // New creates an instance of the OSD manager
@@ -901,6 +902,9 @@ func (c *Cluster) updateCephStorageStatus() error {
 	}
 
 	cephClusterStorage.OSD = *osdStore
+
+	// Add the status about deprecated OSDs
+	cephClusterStorage.DeprecatedOSDs = c.deprecatedOSDs
 
 	err = c.context.Client.Get(c.clusterInfo.Context, c.clusterInfo.NamespacedName(), &cephCluster)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -555,6 +555,13 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	if osdProps.onPVC() {
 		if osd.CVMode == "lvm" {
 			initContainers = append(initContainers, c.getPVCInitContainer(osdProps))
+
+			// This is a deprecated OSD and should be replaced for future supportability
+			if c.deprecatedOSDs == nil {
+				c.deprecatedOSDs = make(map[string][]int)
+			}
+			reason := "LVM-based OSDs on a PVC are deprecated, see documentation on replacing OSDs"
+			c.deprecatedOSDs[reason] = append(c.deprecatedOSDs[reason], osd.ID)
 		} else {
 			// Raw mode on PVC needs this path so that OSD's metadata files can be chown after 'ceph-bluestore-tool' ran
 			dataPath = activateOSDMountPath + osdID


### PR DESCRIPTION
LVM-based OSDs on PVCs are legacy and are not well tested. Therefore, we add status to the cephcluster CR that at least gives a clue that the OSDs should be replaced.

Signed-off-by: Travis Nielsen <tnielsen@redhat.com>
(cherry picked from commit 3628e83892a631dc56f6c42e877e03b0a71d8628) (cherry picked from commit 5a34cd9f9e7fa2aa07dc5ab5f23078ee1968b73f)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #https://bugzilla.redhat.com/show_bug.cgi?id=2274757

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
