### PR TITLE
[BZ 2283643] object: virtulhostnames is not required in the endpoint

### DIFF
--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -348,9 +348,6 @@ func getDomainName(s *cephv1.CephObjectStore, returnRandomDomainIfMultiple bool)
 		for _, e := range s.Spec.Gateway.ExternalRgwEndpoints {
 			endpoints = append(endpoints, e.String())
 		}
-	} else if s.Spec.Hosting != nil && len(s.Spec.Hosting.DNSNames) > 0 {
-		// if the store is internal and has DNS names, pick a random DNS name to use
-		endpoints = s.Spec.Hosting.DNSNames
 	} else {
 		return domainNameOfService(s)
 	}


### PR DESCRIPTION

The virtualhostnames for rgw is added to possible endpoint list, this endpoint is mainly used by rook operator for communicating with RGW server. If enable the virtualhostname feature for rgw, by default the service endpoint is added to the list. So the service endpoint can accessed even if the feature is enabled.


(cherry picked from commit b5d79d1efa4ef2b859af4dd2cf3aa72230105b4a)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
