### PR TITLE
Bug 2293881: osd: revert limit storageClassDeviceSets to 63 chars

### DIFF
--- a/build/csv/ceph/ceph.rook.io_cephclusters.yaml
+++ b/build/csv/ceph/ceph.rook.io_cephclusters.yaml
@@ -1717,7 +1717,6 @@ spec:
                         encrypted:
                           type: boolean
                         name:
-                          maxLength: 40
                           type: string
                         placement:
                           nullable: true

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -3512,7 +3512,6 @@ spec:
                             type: boolean
                           name:
                             description: Name is a unique identifier for the set
-                            maxLength: 40
                             type: string
                           placement:
                             nullable: true

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -3510,7 +3510,6 @@ spec:
                             type: boolean
                           name:
                             description: Name is a unique identifier for the set
-                            maxLength: 40
                             type: string
                           placement:
                             nullable: true

--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -19,8 +19,12 @@ FROM BASEIMAGE
 ARG S5CMD_VERSION
 ARG S5CMD_ARCH
 
-# install 'ip' tool for Multus
-RUN dnf install -y --repo baseos --setopt=install_weak_deps=False iproute && dnf clean all
+# 'ip' tool must be installed for Multus. It's present in the base image today, but it will likely
+# be removed in the future. Doing a 'dnf install' sometimes breaks CI when centos repos go down or
+# have other package build errors. In order to make sure Rook CI catches the eventual removal and
+# also limit Rook CI breakage due to centos breakage, simply check that 'ip' is present.
+# Eventually: dnf install -y --repo baseos --setopt=install_weak_deps=False iproute && dnf clean all
+RUN which ip
 
 # Install the s5cmd package to interact with s3 gateway
 RUN curl --fail -sSL -o /s5cmd.tar.gz https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_${S5CMD_ARCH}.tar.gz && \

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2938,7 +2938,6 @@ type PriorityClassNamesSpec map[KeyType]string
 // +nullable
 type StorageClassDeviceSet struct {
 	// Name is a unique identifier for the set
-	// +kubebuilder:validation:MaxLength=40
 	Name string `json:"name"`
 	// Count is the number of devices in this set
 	// +kubebuilder:validation:Minimum=1

--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -280,20 +280,16 @@ func TestPrepareDeviceSetsWithCrushParams(t *testing.T) {
 }
 
 func TestPVCName(t *testing.T) {
-	id, err := deviceSetPVCID("mydeviceset-making-the-length-of-pvc-id-greater-than-the-limit-63", "a", 0)
-	assert.Error(t, err)
-	assert.Equal(t, "", id)
+	id := deviceSetPVCID("mydeviceset", "a", 0)
+	assert.Equal(t, "mydeviceset-a-0", id)
 
-	id, err = deviceSetPVCID("mydeviceset", "a", 10)
-	assert.NoError(t, err)
+	id = deviceSetPVCID("mydeviceset", "a", 10)
 	assert.Equal(t, "mydeviceset-a-10", id)
 
-	id, err = deviceSetPVCID("device-set", "a", 10)
-	assert.NoError(t, err)
+	id = deviceSetPVCID("device-set", "a", 10)
 	assert.Equal(t, "device-set-a-10", id)
 
-	id, err = deviceSetPVCID("device.set.with.dots", "b", 10)
-	assert.NoError(t, err)
+	id = deviceSetPVCID("device.set.with.dots", "b", 10)
 	assert.Equal(t, "device-set-with-dots-b-10", id)
 }
 


### PR DESCRIPTION
This commits reverts changes done to limit the storageClassDeviceSets Name for 4.16 due to upgrade issues.

There is another commit added in this pr `build: remove iproute build dependency on centos repo` so that most of the build and e2e CI is green

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
