### PR TITLE
Bug 2306577: external: remove the false bool values from config file

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -1568,7 +1568,12 @@ class RadosJSON:
                 # python treats flag-name as flag_name internally, so converting back to flag-name,
                 # so we can get those values from config file
                 argValue = arg.replace("_", "-")
-                if argValue != "config-file":
+                # do not add the config-file flag and also not add the boolean flags which are set to False
+                # because config.ini file treats boolean flags as True always
+                if (
+                    argValue != "config-file"
+                    and getattr(self._arg_parser, arg) != False
+                ):
                     argument += f"{argValue} = {str(getattr(self._arg_parser, arg))}\n"
         return argument
 


### PR DESCRIPTION
currently we created a new config file or user creation, Which was have the user config.

We were also appending the script deafult values to the config file With that all the boolean values were appended to the config.ini file

v2-port-enable = False
....

But the config.ini treat all the bolean values as true, irrespective of they are set to, it is  because the boolean cli flag doesnt accept the argument

So now removed all the false values from the config.ini

Signed-off-by: parth-gr <partharora1010@gmail.com>
(cherry picked from commit d2f8ce4c476cbf69dc9fea6515ff535049192050) (cherry picked from commit 388975cfa4d0bd5aed0be9a18545d5153a326220)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
