### PR TITLE
Bug 2295778: osd: allow the AllowOsdCrushWeightUpdate flag always true

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -325,8 +325,8 @@ func (c *Cluster) postReconcileUpdateOSDProperties(desiredOSDs map[int]*OSDInfo)
 	}
 	logger.Debugf("post processing osd properties with %d actual osds from ceph osd df and %d existing osds found during reconcile", len(osdUsage.OSDNodes), len(desiredOSDs))
 	for _, actualOSD := range osdUsage.OSDNodes {
-		// setting this true for 4.16 downstream, from 4.17 ocs operator will set this to true
-		c.spec.Storage.AllowDeviceClassUpdate = true
+		// setting `AllowOsdCrushWeightUpdate`` true for 4.16 downstream, from 4.17 ocs operator will set this to true
+		c.spec.Storage.AllowOsdCrushWeightUpdate = true
 		if c.spec.Storage.AllowOsdCrushWeightUpdate {
 			_, err := cephclient.ResizeOsdCrushWeight(actualOSD, c.context, c.clusterInfo)
 			if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

This flag is turned on specially for downstream for 4.16

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
