### PR TITLE
Bug 2315733: csi: add sc privileged to logrotate sidecar container

### DIFF
--- a/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-holder.yaml
+++ b/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-holder.yaml
@@ -38,6 +38,8 @@ spec:
           # This is necessary for the Bidirectional mount propagation
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           image: {{ .CSIPluginImage }}
           command:
             - "/bin/sh"

--- a/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -254,6 +254,8 @@ spec:
           {{ if and .Privileged .CSILogRotation }}
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           {{ end }}
           volumeMounts:
             - name: socket-dir

--- a/pkg/operator/ceph/csi/template/csi-logrotate-sidecar.yaml
+++ b/pkg/operator/ceph/csi/template/csi-logrotate-sidecar.yaml
@@ -28,6 +28,12 @@ command:
 image: {{ .CSIPluginImage }}
 imagePullPolicy: IfNotPresent
 name: log-collector
+{{ if .Privileged }}
+securityContext:
+  privileged: true
+  capabilities:
+    drop: ["ALL"]
+{{ end }}
 volumeMounts:
   - mountPath: {{ .CsiLogRootPath }}/logrotate-config/{{ .CsiComponentName }}
     name: csi-logs-logrotate

--- a/pkg/operator/ceph/csi/template/nfs/csi-nfsplugin-holder.yaml
+++ b/pkg/operator/ceph/csi/template/nfs/csi-nfsplugin-holder.yaml
@@ -38,6 +38,8 @@ spec:
           # This is necessary for the Bidirectional mount propagation
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           image: {{ .CSIPluginImage }}
           command:
             - "/bin/sh"

--- a/pkg/operator/ceph/csi/template/nfs/csi-nfsplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/nfs/csi-nfsplugin-provisioner-dep.yaml
@@ -161,6 +161,8 @@ spec:
           {{ if and .Privileged .CSILogRotation }}
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           {{ end }}
           volumeMounts:
             - name: socket-dir

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-holder.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-holder.yaml
@@ -38,6 +38,8 @@ spec:
           # This is necessary for the Bidirectional mount propagation
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           image: {{ .CSIPluginImage }}
           command:
             - "/bin/sh"

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -207,6 +207,8 @@ spec:
           {{ if and .Privileged .CSILogRotation }}
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           {{ end }}
           volumeMounts:
             - name: socket-dir
@@ -263,6 +265,8 @@ spec:
           {{ if and .Privileged .CSILogRotation }}
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           {{ end }}
           volumeMounts:
             - name: socket-dir


### PR DESCRIPTION

deployments on openshift where we need csi container pods
to be run on privileged, the logrotate sidecar container was missing the
privileged permission letting, side car to not run properly

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
