### PR TITLE
multus: remove csi holder pods key

### DIFF
--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -3052,11 +3052,6 @@ spec:
                           configMapKeyRef:
                             key: ROOK_CURRENT_NAMESPACE_ONLY
                             name: ocs-operator-config
-                      - name: CSI_DISABLE_HOLDER_PODS
-                        valueFrom:
-                          configMapKeyRef:
-                            key: CSI_DISABLE_HOLDER_PODS
-                            name: ocs-operator-config
                       - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
                         value: "false"
                       - name: ROOK_LOG_LEVEL

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -691,11 +691,6 @@ spec:
                 configMapKeyRef:
                   key: ROOK_CURRENT_NAMESPACE_ONLY
                   name: ocs-operator-config
-            - name: CSI_DISABLE_HOLDER_PODS
-              valueFrom:
-                configMapKeyRef:
-                  key: CSI_DISABLE_HOLDER_PODS
-                  name: ocs-operator-config
             - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
               value: "false"
             - name: ROOK_LOG_LEVEL


### PR DESCRIPTION
Removed CSI_DISABLE_HOLDER_PODS from the operator deployment files.

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [X] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
