### PR TITLE
DFBUGS-901: ci: fix ci issue downstream

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -45,6 +45,6 @@ jobs:
           # parm: modinfo parameter
           # assigment: inherited from K8s TopologySpreadConstraints dependency
           # ro, RO: means read-only
-          ignore_words_list: aks,keyserver,atleast,ser,ist,ba,iam,te,parm,assigment,ro,RO
+          ignore_words_list: aks,keyserver,atleast,ser,ist,ba,iam,te,parm,assigment,ro,RO,addin,NotIn
           check_filenames: true
           check_hidden: true

--- a/design/ceph/osd-migration.md
+++ b/design/ceph/osd-migration.md
@@ -166,7 +166,7 @@ The OSD prepare pod job will destroy an OSD using following steps:
 
 ## Planning
 
-These changes require ignificant developemnt effort to migrate existing OSDs to use a new backend.
+These changes require ignificant development effort to migrate existing OSDs to use a new backend.
 They will be divided into following phases:
 * New OSDs (greenfield).
 * Migrating existing OSDs on PVC without metadata devices.

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -448,6 +448,8 @@ func TestPostReconcileUpdateOSDProperties(t *testing.T) {
 		assert.Equal(t, "osd.2", removedDeviceClassOSD)
 	})
 	t.Run("test resize Osd Crush Weight", func(t *testing.T) {
+		osdID = make([]string, 0)
+		crushWeight = make([]string, 0)
 		c.spec.Storage = cephv1.StorageScopeSpec{AllowOsdCrushWeightUpdate: true}
 		err := c.postReconcileUpdateOSDProperties(desiredOSDs)
 		assert.Nil(t, err)

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -498,7 +498,7 @@ func TestCephBlockPoolController(t *testing.T) {
 		err := r.client.Update(context.TODO(), pool)
 		assert.NoError(t, err)
 		res, err := r.Reconcile(ctx, req)
-		// assert reconcile failure because peer token secert was not created
+		// assert reconcile failure because peer token secret was not created
 		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
 	})


### PR DESCRIPTION
the unit test ws failing, as in 4.16
we were setting the osd resize manually true,
So the re-weight was called twice once from the
device class update and another from osd reweight

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
