### PR TITLE
DFBUGS-1028: csi: use new flag to enable VGS feature

### DIFF
--- a/pkg/operator/ceph/csi/operator_driver.go
+++ b/pkg/operator/ceph/csi/operator_driver.go
@@ -139,7 +139,7 @@ func (r *ReconcileCSI) createOrUpdateCephFSDriverResource(cluster cephv1.CephClu
 	}
 
 	cephFsDriver.Spec.SnapshotPolicy = csiopv1a1.NoneSnapshotPolicy
-	if CSIParam.EnableVolumeGroupSnapshot {
+	if CSIParam.VolumeGroupSnapshotCLIFlag != "" {
 		cephFsDriver.Spec.SnapshotPolicy = csiopv1a1.VolumeGroupSnapshotPolicy
 	}
 

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -77,8 +77,8 @@ type Param struct {
 	CephFSAttachRequired                     bool
 	RBDAttachRequired                        bool
 	NFSAttachRequired                        bool
+	VolumeGroupSnapshotCLIFlag               string
 	VolumeGroupSnapshotSupported             bool
-	EnableVolumeGroupSnapshot                bool
 	LogLevel                                 uint8
 	SidecarLogLevel                          uint8
 	CephFSLivenessMetricsPort                uint16

--- a/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -63,7 +63,7 @@ spec:
             - "--leader-election-retry-period={{ .LeaderElectionRetryPeriod }}"
             - "--extra-create-metadata=true"
           {{ if .VolumeGroupSnapshotSupported }}
-            - "--enable-volume-group-snapshots={{ .EnableVolumeGroupSnapshot }}"
+            - "{{ .VolumeGroupSnapshotCLIFlag }}"
           {{ end }}
           {{ if .KubeApiBurst }}
             - "--kube-api-burst={{ .KubeApiBurst }}"

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -120,7 +120,7 @@ spec:
             - "--leader-election-retry-period={{ .LeaderElectionRetryPeriod }}"
             - "--extra-create-metadata=true"
             {{ if .VolumeGroupSnapshotSupported }}
-            - "--enable-volume-group-snapshots={{ .EnableVolumeGroupSnapshot }}"
+            - "{{ .VolumeGroupSnapshotCLIFlag }}"
             {{ end }}
             {{ if .KubeApiBurst }}
             - "--kube-api-burst={{ .KubeApiBurst }}"


### PR DESCRIPTION
In the Alpha Version of the VolumeGroupSnapshot
Feature the flag to enable the feature was
`--enable-volume-group-snapshots=true` and in the beta API the feature is diasbled by default to enable it we need to set `--feature-gate=CSIVolumeGroupSnapshot=true`

There is a change in the flag between the API version This PR add a code where we choose the required
flag based on the API version.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit 279e5f7cac0f3e1eb598ff2c5cb0df12eba0195e) (cherry picked from commit fd12192dd48001114a0dfd162dd44ff043fc340c)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
