### PR TITLE
csv: use ROOK_CSI_ENABLE_CEPHFS in rook operator env

### DIFF
--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -3052,6 +3052,11 @@ spec:
                           configMapKeyRef:
                             key: ROOK_CURRENT_NAMESPACE_ONLY
                             name: ocs-operator-config
+                      - name: ROOK_CSI_ENABLE_CEPHFS
+                        valueFrom:
+                          configMapKeyRef:
+                            key: ROOK_CSI_ENABLE_CEPHFS
+                            name: ocs-operator-config
                       - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
                         value: "false"
                       - name: ROOK_LOG_LEVEL

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -688,6 +688,11 @@ spec:
                 configMapKeyRef:
                   key: ROOK_CURRENT_NAMESPACE_ONLY
                   name: ocs-operator-config
+            - name: ROOK_CSI_ENABLE_CEPHFS
+              valueFrom:
+                configMapKeyRef:
+                  key: ROOK_CSI_ENABLE_CEPHFS
+                  name: ocs-operator-config
             - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
               value: "false"
             - name: ROOK_LOG_LEVEL


### PR DESCRIPTION
use the value from ocs operator config by
using the calue from operator env ROOK_CSI_ENABLE_CEPHFS

refer: https://github.com/red-hat-storage/ocs-operator/pull/2970

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
