### PR TITLE
DFBUGS-1696: mgr: Wait for builtin mgr pool to exist before enabling stretch

### DIFF
--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -3455,6 +3455,8 @@ spec:
                 - csiaddonsnodes
               verbs:
                 - get
+                - watch
+                - list
                 - create
                 - update
                 - delete
@@ -3485,6 +3487,8 @@ spec:
                 - csiaddonsnodes
               verbs:
                 - get
+                - watch
+                - list
                 - create
                 - update
                 - delete
@@ -3526,6 +3530,8 @@ spec:
                 - csiaddonsnodes
               verbs:
                 - get
+                - watch
+                - list
                 - create
                 - update
                 - delete

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -169,13 +169,30 @@ func canIgnoreHealthErrStatusInReconcile(cephCluster cephv1.CephCluster, control
 		}
 	}
 
-	// If there is only one cause for HEALTH_ERR and it's on the allowed list of errors, ignore it.
-	var allowedErrStatus = []string{"MDS_ALL_DOWN"}
-	var ignoreHealthErr = len(healthErrKeys) == 1 && contains(allowedErrStatus, healthErrKeys[0])
-	if ignoreHealthErr {
-		logger.Debugf("%q: ignoring ceph status %q because only cause is %q (full status is %+v)", controllerName, cephCluster.Status.CephStatus.Health, healthErrKeys[0], cephCluster.Status.CephStatus)
+	// If there are no errors, the caller actually expects false to be returned so the absence
+	// of an error doesn't cause the health status to be ignored. In production, if there are no
+	// errors, we would anyway expect the health status to be ok or warning. False in this case
+	// will cover if the health status is blank.
+	if len(healthErrKeys) == 0 {
+		return false
 	}
-	return ignoreHealthErr
+
+	allowedErrStatus := map[string]struct{}{
+		"MDS_ALL_DOWN":     {},
+		"MGR_MODULE_ERROR": {},
+	}
+	allCanBeIgnored := true
+	for _, healthErrKey := range healthErrKeys {
+		if _, ok := allowedErrStatus[healthErrKey]; !ok {
+			allCanBeIgnored = false
+			break
+		}
+	}
+	if allCanBeIgnored {
+		logger.Debugf("%q: ignoring ceph error status (full status is %+v)", controllerName, cephCluster.Status.CephStatus)
+		return true
+	}
+	return false
 }
 
 // IsReadyToReconcile determines if a controller is ready to reconcile or not

--- a/pkg/operator/ceph/controller/controller_utils_test.go
+++ b/pkg/operator/ceph/controller/controller_utils_test.go
@@ -45,7 +45,11 @@ func TestCanIgnoreHealthErrStatusInReconcile(t *testing.T) {
 	var cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
 		"MDS_ALL_DOWN": {
 			Severity: "HEALTH_ERR",
-			Message:  "MDS_ALL_DOWN",
+			Message:  "mds all down error",
+		},
+		"MGR_MODULE_ERROR": {
+			Severity: "HEALTH_ERR",
+			Message:  "mgr module error",
 		},
 		"TEST_OTHER": {
 			Severity: "HEALTH_WARN",
@@ -57,6 +61,22 @@ func TestCanIgnoreHealthErrStatusInReconcile(t *testing.T) {
 		},
 	})
 	assert.True(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
+
+	cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
+		"MGR_MODULE_ERROR": {
+			Severity: "HEALTH_ERR",
+			Message:  "mgr module error",
+		},
+	})
+	assert.True(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
+
+	cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
+		"MGR_MODULE_ERROR_FALSE": {
+			Severity: "HEALTH_ERR",
+			Message:  "mgr module error",
+		},
+	})
+	assert.False(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
 
 	cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
 		"MDS_ALL_DOWN": {
@@ -76,6 +96,10 @@ func TestCanIgnoreHealthErrStatusInReconcile(t *testing.T) {
 			Message:  "TEST_UNIGNORABLE",
 		},
 	})
+	assert.False(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
+
+	// The empty status should return false
+	cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{})
 	assert.False(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
 }
 

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -254,6 +254,7 @@ func TestCephFilesystemController(t *testing.T) {
 			recorder:         record.NewFakeRecorder(5),
 			scheme:           s,
 			context:          c,
+			fsContexts:       make(map[string]*fsHealth),
 			opManagerContext: context.TODO(),
 		}
 		res, err := r.Reconcile(ctx, req)

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -1091,7 +1091,7 @@ func createSimilarPools(ctx *Context, pools []string, cluster *cephv1.ClusterSpe
 	if configurePoolsConcurrently() {
 		waitGroup, _ := errgroup.WithContext(ctx.clusterInfo.Context)
 		for _, pool := range pools {
-			// Avoid the loop re-using the same value with a closure
+			// Avoid the loop reusing the same value with a closure
 			pool := pool
 
 			waitGroup.Go(func() error { return createRGWPool(ctx, cluster, poolSpec, pgCount, pool) })

--- a/tests/scripts/multus/host-cfg-ds.yaml
+++ b/tests/scripts/multus/host-cfg-ds.yaml
@@ -51,7 +51,7 @@ spec:
               last="${ip##*.}" # e.g., 3
 
               # add a shim to connect IFACE to the macvlan public network, with a static IP
-              # avoid IP conflicts by re-using the last part of the existing IFACE IP
+              # avoid IP conflicts by reusing the last part of the existing IFACE IP
               ip link add public-shim link ${IFACE} type macvlan mode bridge
               ip addr add ${NODE_PUBLIC_NET_IP_FIRST3}.${last}/24 dev public-shim
               ip link set public-shim up


### PR DESCRIPTION
There is a race condition in ceph v19 at startup of a stretch cluster where if the .mgr pool is created by the mgr pod after stretch mode is entered, the devicehealth mgr module will crash and cause a ceph HEALTH_ERR. The error then causes rook reconcile of all CRs to be skipped because Rook is assuming admin intervention is needed to continue. The fix is to wait until the .mgr pool is created by the mgr pod before entering stretch mode.

At the same time, we suppress mgr module health errors during reconcile. Some ceph health errors should not block the reconcile of the cluster. Mgr modules do not have cause to block the reconcile, as the cluster can usually work even if a module is failing.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
