### PR TITLE
csi: let's not delete csi driver object

### DIFF
--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -48,7 +48,16 @@ func (r *ReconcileCSI) validateAndConfigureDrivers(ownerInfo *k8sutil.OwnerInfo)
 	}
 
 	// Check whether RBD or CephFS needs to be disabled
-	return r.stopDrivers()
+	err = r.stopDrivers()
+	if err != nil {
+		return errors.Wrap(err, "failed to stop Drivers")
+	}
+
+	err = r.deleteCSIDriverObject()
+	if err != nil {
+		return errors.Wrap(err, "failed to delete Drivers object")
+	}
+	return nil
 }
 
 func (r *ReconcileCSI) setParams() error {

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -662,13 +662,9 @@ func (r *ReconcileCSI) startDrivers(ownerInfo *k8sutil.OwnerInfo) error {
 }
 
 func (r *ReconcileCSI) stopDrivers() error {
-	RBDDriverName = fmt.Sprintf("%s.rbd.csi.ceph.com", r.opConfig.OperatorNamespace)
-	CephFSDriverName = fmt.Sprintf("%s.cephfs.csi.ceph.com", r.opConfig.OperatorNamespace)
-	NFSDriverName = fmt.Sprintf("%s.nfs.csi.ceph.com", r.opConfig.OperatorNamespace)
-
 	if !EnableRBD || EnableCSIOperator() {
 		logger.Debugf("either EnableRBD if `false` or EnableCSIOperator is `true`, `EnableRBD is %t` and `EnableCSIOperator is %t", EnableRBD, EnableCSIOperator())
-		err := r.deleteCSIDriverResources(CsiRBDPlugin, csiRBDProvisioner, "csi-rbdplugin-metrics", RBDDriverName)
+		err := r.deleteCSIDriverResources(CsiRBDPlugin, csiRBDProvisioner, "csi-rbdplugin-metrics")
 		if err != nil {
 			return errors.Wrap(err, "failed to remove CSI Ceph RBD driver")
 		}
@@ -677,7 +673,7 @@ func (r *ReconcileCSI) stopDrivers() error {
 
 	if !EnableCephFS || EnableCSIOperator() {
 		logger.Debugf("either EnableCephFS if `false` or EnableCSIOperator is `true`, `EnableCephFS is %t` and `EnableCSIOperator is %t", EnableRBD, EnableCSIOperator())
-		err := r.deleteCSIDriverResources(CsiCephFSPlugin, csiCephFSProvisioner, "csi-cephfsplugin-metrics", CephFSDriverName)
+		err := r.deleteCSIDriverResources(CsiCephFSPlugin, csiCephFSProvisioner, "csi-cephfsplugin-metrics")
 		if err != nil {
 			return errors.Wrap(err, "failed to remove CSI CephFS driver")
 		}
@@ -686,7 +682,7 @@ func (r *ReconcileCSI) stopDrivers() error {
 
 	if !EnableNFS || EnableCSIOperator() {
 		logger.Debugf("either EnableNFS if `false` or EnableCSIOperator is `true`, `EnableNFS is %t` and `EnableCSIOperator is %t", EnableRBD, EnableCSIOperator())
-		err := r.deleteCSIDriverResources(CsiNFSPlugin, csiNFSProvisioner, "csi-nfsplugin-metrics", NFSDriverName)
+		err := r.deleteCSIDriverResources(CsiNFSPlugin, csiNFSProvisioner, "csi-nfsplugin-metrics")
 		if err != nil {
 			return errors.Wrap(err, "failed to remove CSI NFS driver")
 		}
@@ -696,8 +692,7 @@ func (r *ReconcileCSI) stopDrivers() error {
 	return nil
 }
 
-func (r *ReconcileCSI) deleteCSIDriverResources(daemonset, deployment, service, driverName string) error {
-	csiDriverobj := v1CsiDriver{}
+func (r *ReconcileCSI) deleteCSIDriverResources(daemonset, deployment, service string) error {
 	err := k8sutil.DeleteDaemonset(r.opManagerContext, r.context.Clientset, r.opConfig.OperatorNamespace, daemonset)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete the %q", daemonset)
@@ -713,13 +708,24 @@ func (r *ReconcileCSI) deleteCSIDriverResources(daemonset, deployment, service, 
 		return errors.Wrapf(err, "failed to delete the %q", service)
 	}
 
-	if !EnableCSIOperator() {
-		err = csiDriverobj.deleteCSIDriverInfo(r.opManagerContext, r.context.Clientset, driverName)
-		if err != nil {
-			return errors.Wrapf(err, "failed to delete %q Driver Info", driverName)
+	return nil
+}
+
+func (r *ReconcileCSI) deleteCSIDriverObject() error {
+	RBDDriverName = fmt.Sprintf("%s.rbd.csi.ceph.com", r.opConfig.OperatorNamespace)
+	CephFSDriverName = fmt.Sprintf("%s.cephfs.csi.ceph.com", r.opConfig.OperatorNamespace)
+	NFSDriverName = fmt.Sprintf("%s.nfs.csi.ceph.com", r.opConfig.OperatorNamespace)
+	driverNames := []string{RBDDriverName, CephFSDriverName, NFSDriverName}
+
+	for _, driverName := range driverNames {
+		csiDriverobj := v1CsiDriver{}
+		if !EnableCSIOperator() {
+			err := csiDriverobj.deleteCSIDriverInfo(r.opManagerContext, r.context.Clientset, driverName)
+			if err != nil {
+				return errors.Wrapf(err, "failed to delete %q Driver Info", driverName)
+			}
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
in upgrade case, if there is csi driver already created by other owners and disableCSI is changed `true` and EnableUseCSIOperator and is `false`. Rook was deleting the CSI driver object. So, with my code changes, the csi driver object will be deleted where it is required and not all the time when we are deleting the older csi resources.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
