### PR TITLE
rgw: remove v20 check for rgw-readaffinity

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -468,7 +468,7 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) (v1.Container,
 	// set RGW read Affinity
 	isCrushLocationSet := false
 	if c.store.Spec.Gateway.ReadAffinity != nil {
-		if c.clusterInfo.CephVersion.IsAtLeastTentacle() {
+		if c.clusterInfo.CephVersion.IsAtLeastSquid() {
 			container.Args = append(container.Args, cephconfig.NewFlag(radosReadReplicaPolicy, c.store.Spec.Gateway.ReadAffinity.Type))
 			// set crush location if `balance` and `default` mode are not set.
 			if c.store.Spec.Gateway.ReadAffinity.Type != balanceReadReplicaPolicy && c.store.Spec.Gateway.ReadAffinity.Type != defaultReadReplicaPolicy {
@@ -476,7 +476,7 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) (v1.Container,
 				isCrushLocationSet = true
 			}
 		} else {
-			logger.Warning("can't set RGW read affinity for ceph version below v20 (tentacle)")
+			logger.Warning("can't set RGW read affinity for ceph version below v19 (Squid)")
 		}
 	}
 

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -1577,29 +1577,29 @@ func TestRgwReadAffinity(t *testing.T) {
 		isCrushLocationArgSet bool
 	}{
 		{
-			name:                  "ceph version is less than v.20",
+			name:                  "ceph version is less than v.19",
 			cephVersion:           cephver.CephVersion{Major: 17, Minor: 2, Extra: 3},
 			readAffinity:          "localize",
 			isReadAffinityArgSet:  false,
 			isCrushLocationArgSet: false,
 		},
 		{
-			name:                  "ceph version is v.20 and localized read affinity is set",
-			cephVersion:           cephver.CephVersion{Major: 20, Minor: 0, Extra: 0},
+			name:                  "ceph version is v.19 and localized read affinity is set",
+			cephVersion:           cephver.CephVersion{Major: 19, Minor: 0, Extra: 0},
 			readAffinity:          "localize",
 			isReadAffinityArgSet:  true,
 			isCrushLocationArgSet: true,
 		},
 		{
-			name:                  "ceph version is v.20 and balanced read affinity is set",
-			cephVersion:           cephver.CephVersion{Major: 20, Minor: 0, Extra: 0},
+			name:                  "ceph version is v.19 and balanced read affinity is set",
+			cephVersion:           cephver.CephVersion{Major: 19, Minor: 0, Extra: 0},
 			readAffinity:          "balance",
 			isReadAffinityArgSet:  true,
 			isCrushLocationArgSet: false,
 		},
 		{
-			name:                  "ceph version is v.20 and default read affinity is set",
-			cephVersion:           cephver.CephVersion{Major: 20, Minor: 0, Extra: 0},
+			name:                  "ceph version is v.19 and default read affinity is set",
+			cephVersion:           cephver.CephVersion{Major: 19, Minor: 0, Extra: 0},
 			readAffinity:          "default",
 			isReadAffinityArgSet:  true,
 			isCrushLocationArgSet: false,


### PR DESCRIPTION
rgw ReadAffinity is also supported for v.19 in ceph downstream. This PR removes the ceph version requirement 4.19 ODF

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
