### PR TITLE
DFBUGS-2089: rbdmirror: fix the rados namespace health checkup

### DIFF
--- a/pkg/daemon/ceph/client/mirror_health.go
+++ b/pkg/daemon/ceph/client/mirror_health.go
@@ -114,8 +114,9 @@ func (c *mirrorChecker) CheckMirroringHealth() error {
 	}
 
 	// On success
-	c.UpdateStatusMirroring(mirrorStatus.Summary, mirrorInfo, snapSchedStatus, "")
-
+	if mirrorStatus.Summary != nil {
+		c.UpdateStatusMirroring(mirrorStatus.Summary, mirrorInfo, snapSchedStatus, "")
+	}
 	return nil
 }
 


### PR DESCRIPTION
there was very edge case,a nd that result in nil
point exception
During osd upgrades if mirror health check is called the mirror status cmd doesnt respond
So its important to check if the value exist
before getting its summary

Signed-off-by: parth-gr <partharora1010@gmail.com>
(cherry picked from commit 0c5d3ee3a56573904d56ad4a7080c7fe2128e428)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
