### PR TITLE
DFBUGS-2586: nfs: fix nfs config file 4.18

### DIFF
--- a/pkg/operator/ceph/nfs/config_test.go
+++ b/pkg/operator/ceph/nfs/config_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2025 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package nfs to manage a rook ceph nfs
+package nfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNFSNodeID(t *testing.T) {
+	nfsNodeID := getNFSNodeID("a")
+	assert.Equal(t, "0", nfsNodeID)
+
+	nfsNodeID = getNFSNodeID("b")
+	assert.Equal(t, "1", nfsNodeID)
+
+	nfsNodeID = getNFSNodeID("aa")
+	assert.Equal(t, "26", nfsNodeID)
+}

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -124,8 +124,14 @@ func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS) error {
 			return errors.Wrap(err, "failed to create ceph nfs service")
 		}
 
+		// with upgrades remove old server from database
+		deprecatedNodeID := getDeprecatedNFSNodeID(n, id)
+		r.removeServerFromDatabase(n, deprecatedNodeID)
+		r.removeServerFromDatabase(n, fmt.Sprintf("node%s", deprecatedNodeID))
+
 		// Add server to database
-		err = r.addServerToDatabase(n, id)
+		nodeID := getNFSNodeID(id)
+		err = r.addServerToDatabase(n, fmt.Sprintf("node%s", nodeID))
 		if err != nil {
 			return errors.Wrapf(err, "failed to add server %q to database", id)
 		}
@@ -159,26 +165,25 @@ func (r *ReconcileCephNFS) addRADOSConfigFile(n *cephv1.CephNFS) error {
 	return nil
 }
 
-func (r *ReconcileCephNFS) addServerToDatabase(nfs *cephv1.CephNFS, name string) error {
-	logger.Infof("adding ganesha %q to grace db", name)
+func (r *ReconcileCephNFS) addServerToDatabase(nfs *cephv1.CephNFS, nodeID string) error {
+	logger.Infof("adding ganesha %q to grace db", nodeID)
 
-	if err := r.runGaneshaRadosGrace(nfs, name, "add"); err != nil {
-		return errors.Wrapf(err, "failed to add %q to grace db", name)
+	if err := r.runGaneshaRadosGrace(nfs, nodeID, "add"); err != nil {
+		return errors.Wrapf(err, "failed to add %q to grace db", nodeID)
 	}
 
 	return nil
 }
 
-func (r *ReconcileCephNFS) removeServerFromDatabase(nfs *cephv1.CephNFS, name string) {
-	logger.Infof("removing ganesha %q from grace db", name)
+func (r *ReconcileCephNFS) removeServerFromDatabase(nfs *cephv1.CephNFS, nodeID string) {
+	logger.Infof("removing ganesha %q from grace db", nodeID)
 
-	if err := r.runGaneshaRadosGrace(nfs, name, "remove"); err != nil {
-		logger.Errorf("failed to remove %q from grace db. %v", name, err)
+	if err := r.runGaneshaRadosGrace(nfs, nodeID, "remove"); err != nil {
+		logger.Debugf("failed to remove %q from grace db. %v", nodeID, err)
 	}
 }
 
-func (r *ReconcileCephNFS) runGaneshaRadosGrace(nfs *cephv1.CephNFS, name, action string) error {
-	nodeID := getNFSNodeID(nfs, name)
+func (r *ReconcileCephNFS) runGaneshaRadosGrace(nfs *cephv1.CephNFS, nodeID, action string) error {
 	args := []string{"--pool", nfs.Spec.RADOS.Pool, "--ns", nfs.Spec.RADOS.Namespace, action, nodeID}
 	cmd := cephclient.NewGaneshaRadosGraceCommand(r.context, r.clusterInfo, args)
 	_, err := cmd.RunWithTimeout(exec.CephCommandsTimeout)
@@ -188,7 +193,7 @@ func (r *ReconcileCephNFS) runGaneshaRadosGrace(nfs *cephv1.CephNFS, name, actio
 func (r *ReconcileCephNFS) generateConfigMap(n *cephv1.CephNFS, name string) *v1.ConfigMap {
 
 	data := map[string]string{
-		"config": getGaneshaConfig(n, r.clusterInfo.CephVersion, name),
+		"config": getGaneshaConfig(n, name),
 	}
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -252,7 +257,8 @@ func (r *ReconcileCephNFS) downCephNFS(n *cephv1.CephNFS, nfsServerListNum int) 
 		}
 
 		// Remove from grace db
-		r.removeServerFromDatabase(n, name)
+		nodeID := getNFSNodeID(name)
+		r.removeServerFromDatabase(n, fmt.Sprintf("node%s", nodeID))
 
 		// Remove deployment
 		// since we list deployments to determine what to remove, have to remove deployment last
@@ -270,7 +276,8 @@ func (r *ReconcileCephNFS) downCephNFS(n *cephv1.CephNFS, nfsServerListNum int) 
 func (r *ReconcileCephNFS) removeServersFromDatabase(n *cephv1.CephNFS, newActive int) error {
 	for i := n.Spec.Server.Active - 1; i >= newActive; i-- {
 		name := k8sutil.IndexToName(i)
-		r.removeServerFromDatabase(n, name)
+		nodeID := getNFSNodeID(name)
+		r.removeServerFromDatabase(n, fmt.Sprintf("node%s", nodeID))
 	}
 
 	return nil

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -207,7 +207,7 @@ func (r *ReconcileCephNFS) connectionConfigInitContainer(nfs *cephv1.CephNFS, na
 	_, cephConfigMount := cephConfigVolumeAndMount()
 
 	return controller.GenerateMinimalCephConfInitContainer(
-		getNFSClientID(nfs, name),
+		getNFSClientID(name),
 		keyring.VolumeMount().KeyringFilePath(),
 		r.cephClusterSpec.CephVersion.Image,
 		r.cephClusterSpec.CephVersion.ImagePullPolicy,


### PR DESCRIPTION
the nfs config flie has a breaking change
to use nodeid as int,
currently nodeid was used as string

updated the code so nodeid can be used as string


(cherry picked from commit 7f465cb320cdbb200dad3e45679be28b067099f9)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
