### PR TITLE
DFBUGS-2564: nfs: fix nfs config file

### DIFF
--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -131,7 +131,7 @@ func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS) error {
 
 		// Add server to database
 		nodeID := getNFSNodeID(id)
-		err = r.addServerToDatabase(n, fmt.Sprintf("node%s", nodeID))
+		err = r.addServerToDatabase(n, nodeID)
 		if err != nil {
 			return errors.Wrapf(err, "failed to add server %q to database", id)
 		}
@@ -257,7 +257,7 @@ func (r *ReconcileCephNFS) downCephNFS(n *cephv1.CephNFS, nfsServerListNum int) 
 
 		// Remove from grace db
 		nodeID := getNFSNodeID(name)
-		r.removeServerFromDatabase(n, fmt.Sprintf("node%s", nodeID))
+		r.removeServerFromDatabase(n, nodeID)
 
 		// Remove deployment
 		// since we list deployments to determine what to remove, have to remove deployment last
@@ -276,7 +276,7 @@ func (r *ReconcileCephNFS) removeServersFromDatabase(n *cephv1.CephNFS, newActiv
 	for i := n.Spec.Server.Active - 1; i >= newActive; i-- {
 		name := k8sutil.IndexToName(i)
 		nodeID := getNFSNodeID(name)
-		r.removeServerFromDatabase(n, fmt.Sprintf("node%s", nodeID))
+		r.removeServerFromDatabase(n, nodeID)
 	}
 
 	return nil


### PR DESCRIPTION
the nfs config flie has a breaking change
to use nodeid as int,
currently nodeid was used as string

updated the code so nodeid can be used as string

It fixes the double append of `nodenode0` and now only appends `node0`


(cherry picked from commit 869530501a30744b1a85d2139a1f1f782437be23)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
