### PR TITLE
DFBUGS-2650: nfs: skip NFS daemon reconciliation when labeled with skip-reconcile

### DIFF
--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -49,9 +49,6 @@ const (
 	// RgwType defines the rgw DaemonType
 	RgwType = "rgw"
 
-	// NfsType defines the nfs DaemonType
-	NfsType = "nfs"
-
 	// RbdMirrorType defines the rbd-mirror DaemonType
 	RbdMirrorType = "rbd-mirror"
 

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -566,7 +566,7 @@ func TestGetDaemonsToSkipReconcile(t *testing.T) {
 			labels: map[string]string{
 				k8sutil.AppAttr:              "rook-ceph-nfs",
 				cephv1.SkipReconcileLabelKey: "true",
-				config.NfsType:               "a",
+				"instance":                   "a",
 			},
 			expectedSkip:     true,
 			expectedDaemonID: "a",
@@ -575,7 +575,7 @@ func TestGetDaemonsToSkipReconcile(t *testing.T) {
 			name: "no skip-reconcile label",
 			labels: map[string]string{
 				k8sutil.AppAttr: "rook-ceph-nfs",
-				config.NfsType:  "b",
+				"instance":      "b",
 			},
 			expectedSkip:     false,
 			expectedDaemonID: "b",
@@ -585,7 +585,7 @@ func TestGetDaemonsToSkipReconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			namespace := "rook-ceph"
-			daemonName := "nfs"
+			daemonName := "instance"
 			appLabel := "rook-ceph-nfs"
 
 			clientset := test.New(t, 1)

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -55,7 +55,7 @@ type daemonConfig struct {
 
 // Create the ganesha server
 func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS) error {
-	nfsToSkipReconcile, err := controller.GetDaemonsToSkipReconcile(r.clusterInfo.Context, r.context, n.Namespace, config.NfsType, AppName)
+	nfsToSkipReconcile, err := controller.GetDaemonsToSkipReconcile(r.clusterInfo.Context, r.context, n.Namespace, "instance", AppName)
 	if err != nil {
 		return errors.Wrap(err, "failed to check for NFS daemons to skip reconcile")
 	}

--- a/pkg/operator/ceph/nfs/nfs_test.go
+++ b/pkg/operator/ceph/nfs/nfs_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
-	"github.com/rook/rook/pkg/operator/ceph/config"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -216,7 +215,7 @@ func TestReconcileCephNFS_upCephNFS(t *testing.T) {
 func TestUpCephNFS_SkipsReconcile(t *testing.T) {
 	ns := "skip-nfs-test"
 	s := scheme.Scheme
-	daemonID := "a"
+	instance := "a"
 
 	clientset := k8sfake.NewSimpleClientset()
 	client := fake.NewClientBuilder().WithScheme(s).Build()
@@ -228,7 +227,7 @@ func TestUpCephNFS_SkipsReconcile(t *testing.T) {
 			Labels: map[string]string{
 				k8sutil.AppAttr:              AppName,
 				cephv1.SkipReconcileLabelKey: "true",
-				config.NfsType:               daemonID,
+				"instance":                   instance,
 			},
 		},
 	}


### PR DESCRIPTION
This change adds support for skipping reconciliation of CephNFS daemons that are labeled with `ceph.rook.io/skip-reconcile=true`. Similar to MDS, MGR, and RGW components, this allows cluster operators to prevent Rook from modifying specific NFS daemon deployments.


(cherry picked from commit 612e54e1ae0e0adcacee7fe885109d508ba9fa63)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
