### PR TITLE
DFBUGS-2649: nfs: skip NFS daemon reconciliation when labeled with skip-reconcile

### DIFF
--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -49,6 +49,9 @@ const (
 	// RgwType defines the rgw DaemonType
 	RgwType = "rgw"
 
+	// NfsType defines the nfs DaemonType
+	NfsType = "nfs"
+
 	// RbdMirrorType defines the rbd-mirror DaemonType
 	RbdMirrorType = "rbd-mirror"
 


### PR DESCRIPTION
This change adds support for skipping reconciliation of CephNFS daemons that are labeled with `ceph.rook.io/skip-reconcile=true`. Similar to MDS, MGR, and RGW components, this allows cluster operators to prevent Rook from modifying specific NFS daemon deployments.


(cherry picked from commit 612e54e1ae0e0adcacee7fe885109d508ba9fa63)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
