### PR TITLE
DFBUGS-2645: nfs: remove the nodeid from the server thats not used

### DIFF
--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -135,8 +135,13 @@ func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS) error {
 			return errors.Wrap(err, "failed to create ceph nfs service")
 		}
 
+		// needed for 4.18.5 upgrade from 4.18.4
+		deprecatedNodeID := fmt.Sprintf("node%s", getNFSNodeID(n, id))
+		r.removeServerFromDatabase(n, deprecatedNodeID)
+
 		// Add server to database
-		err = r.addServerToDatabase(n, id)
+		nodeID := getNFSNodeID(n, id)
+		err = r.addServerToDatabase(n, nodeID)
 		if err != nil {
 			return errors.Wrapf(err, "failed to add server %q to database", id)
 		}
@@ -170,26 +175,25 @@ func (r *ReconcileCephNFS) addRADOSConfigFile(n *cephv1.CephNFS) error {
 	return nil
 }
 
-func (r *ReconcileCephNFS) addServerToDatabase(nfs *cephv1.CephNFS, name string) error {
-	logger.Infof("adding ganesha %q to grace db", name)
+func (r *ReconcileCephNFS) addServerToDatabase(nfs *cephv1.CephNFS, node string) error {
+	logger.Infof("adding ganesha %q to grace db", node)
 
-	if err := r.runGaneshaRadosGrace(nfs, name, "add"); err != nil {
-		return errors.Wrapf(err, "failed to add %q to grace db", name)
+	if err := r.runGaneshaRadosGrace(nfs, node, "add"); err != nil {
+		return errors.Wrapf(err, "failed to add %q to grace db", node)
 	}
 
 	return nil
 }
 
-func (r *ReconcileCephNFS) removeServerFromDatabase(nfs *cephv1.CephNFS, name string) {
-	logger.Infof("removing ganesha %q from grace db", name)
+func (r *ReconcileCephNFS) removeServerFromDatabase(nfs *cephv1.CephNFS, nodeID string) {
+	logger.Infof("removing ganesha %q from grace db", nodeID)
 
-	if err := r.runGaneshaRadosGrace(nfs, name, "remove"); err != nil {
-		logger.Errorf("failed to remove %q from grace db. %v", name, err)
+	if err := r.runGaneshaRadosGrace(nfs, nodeID, "remove"); err != nil {
+		logger.Debugf("failed to remove %q from grace db. %v", nodeID, err)
 	}
 }
 
-func (r *ReconcileCephNFS) runGaneshaRadosGrace(nfs *cephv1.CephNFS, name, action string) error {
-	nodeID := getNFSNodeID(nfs, name)
+func (r *ReconcileCephNFS) runGaneshaRadosGrace(nfs *cephv1.CephNFS, nodeID, action string) error {
 	args := []string{"--pool", nfs.Spec.RADOS.Pool, "--ns", nfs.Spec.RADOS.Namespace, action, nodeID}
 	cmd := cephclient.NewGaneshaRadosGraceCommand(r.context, r.clusterInfo, args)
 	_, err := cmd.RunWithTimeout(exec.CephCommandsTimeout)
@@ -197,7 +201,6 @@ func (r *ReconcileCephNFS) runGaneshaRadosGrace(nfs *cephv1.CephNFS, name, actio
 }
 
 func (r *ReconcileCephNFS) generateConfigMap(n *cephv1.CephNFS, name string) *v1.ConfigMap {
-
 	data := map[string]string{
 		"config": getGaneshaConfig(n, r.clusterInfo.CephVersion, name),
 	}
@@ -263,7 +266,8 @@ func (r *ReconcileCephNFS) downCephNFS(n *cephv1.CephNFS, nfsServerListNum int) 
 		}
 
 		// Remove from grace db
-		r.removeServerFromDatabase(n, name)
+		nodeID := getNFSNodeID(n, name)
+		r.removeServerFromDatabase(n, nodeID)
 
 		// Remove deployment
 		// since we list deployments to determine what to remove, have to remove deployment last
@@ -281,11 +285,13 @@ func (r *ReconcileCephNFS) downCephNFS(n *cephv1.CephNFS, nfsServerListNum int) 
 func (r *ReconcileCephNFS) removeServersFromDatabase(n *cephv1.CephNFS, newActive int) error {
 	for i := n.Spec.Server.Active - 1; i >= newActive; i-- {
 		name := k8sutil.IndexToName(i)
-		r.removeServerFromDatabase(n, name)
+		nodeID := getNFSNodeID(n, name)
+		r.removeServerFromDatabase(n, nodeID)
 	}
 
 	return nil
 }
+
 func instanceName(n *cephv1.CephNFS, name string) string {
 	return fmt.Sprintf("%s-%s-%s", AppName, n.Name, name)
 }


### PR DESCRIPTION
In ODF 4.17 we had a server as ocs-storagecluster-cephnfs.a Upgrades from ODF 4.17 to ODF 4.18.3/,
Rook would have added a server which would be
`node.ocs-storagecluster-cephnfs.a`
So that means we have two server in the dump,

Now if we upgrade to ODF 4.18.5 from odf 4.18.3/4, We also need to remove the
`node.ocs-storagecluster-cephnfs.a`

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
