### PR TITLE
DFBUGS-2744: pool: blocklist rns image watchers

### DIFF
--- a/pkg/daemon/ceph/cleanup/radosnamespace.go
+++ b/pkg/daemon/ceph/cleanup/radosnamespace.go
@@ -23,6 +23,13 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+
+	// ClientBlocklistDuration is the duration (in seconds) for which the client IP will be blocklisted
+	ClientBlocklistDuration = "1200"
 )
 
 func RadosNamespaceCleanup(context *clusterd.Context, clusterInfo *client.ClusterInfo, poolName, radosNamespace string) error {
@@ -46,6 +53,11 @@ func cleanupImages(context *clusterd.Context, clusterInfo *client.ClusterInfo, p
 	images, err := cephclient.ListImagesInRadosNamespace(context, clusterInfo, poolName, radosNamespace)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list images in %s", msg)
+	}
+
+	err = blocklistClientIPs(context, clusterInfo, images, poolName, radosNamespace)
+	if err != nil {
+		return errors.Wrap(err, "failed to add client IPs to the blocklist")
 	}
 
 	var retErr error
@@ -91,4 +103,49 @@ func BlockPoolCleanup(context *clusterd.Context, clusterInfo *client.ClusterInfo
 
 	logger.Infof("successfully cleaned up CephBlockPool %q resource", poolName)
 	return nil
+}
+
+func blocklistClientIPs(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, images []cephclient.CephBlockImage, poolName, radosNamespace string) error {
+	ips, err := getClientIPs(context, clusterInfo, images, poolName, radosNamespace)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get client IPs for all the images in pool %q in namespace %q", poolName, radosNamespace)
+	}
+
+	if len(ips) == 0 {
+		logger.Info("no client IPs found for images in pool %q in rados namespace %q", poolName, radosNamespace)
+	}
+
+	for ip := range ips {
+		logger.Infof("blocklist client IP %q for images in pool %q in namespace %q", ip, poolName, radosNamespace)
+		err = cephclient.BlocklistIP(context, clusterInfo, ip, ClientBlocklistDuration)
+		if err != nil {
+			return errors.Wrapf(err, "failed to blocklist IP  %q in pool %q in namespace %q", ip, poolName, radosNamespace)
+		}
+		logger.Infof("successfully blocklisted client IP %q in pool %q in namespace %q", ip, poolName, radosNamespace)
+	}
+
+	return nil
+}
+
+func getClientIPs(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, images []cephclient.CephBlockImage, poolName, radosNamespace string) (sets.Set[string], error) {
+	clientIPs := sets.New[string]()
+	for _, image := range images {
+		rbdStatus, err := cephclient.GetRBDImageStatus(context, clusterInfo, poolName, image.Name, radosNamespace)
+		if err != nil {
+			return clientIPs, errors.Wrapf(err, "failed to list watchers for the image %q in %s", image.Name, radosNamespace)
+		}
+		ips := rbdStatus.GetWatcherIPs()
+		if len(ips) == 0 {
+			logger.Infof("no watcher IPs found for image %q in pool %q in namespace %q", image.Name, poolName, radosNamespace)
+			continue
+		}
+
+		logger.Infof("watcher IPs for image %q in pool %q in namespace %q: %v", image.Name, poolName, radosNamespace, ips)
+		for _, ip := range ips {
+			clientIPs.Insert(ip)
+		}
+	}
+
+	logger.Infof("client IPs : %v", clientIPs)
+	return clientIPs, nil
 }

--- a/pkg/daemon/ceph/client/image.go
+++ b/pkg/daemon/ceph/client/image.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -291,4 +292,44 @@ func getImageSpecInRadosNamespace(poolName, namespace, imageID string) string {
 
 func getImageSnapshotSpec(poolName, imageName, snapshot string) string {
 	return fmt.Sprintf("%s/%s@%s", poolName, imageName, snapshot)
+}
+
+type RBDStatus struct {
+	Watchers []struct {
+		Address string `json:"address"`
+	} `json:"watchers"`
+}
+
+// GetWatcherIPs returns a list of watcher IPs of the RBD image.
+// The RBD status output is parsed to get the desired IPs.
+// For example: `192.168.39.137:0/3762982934“ IP format returned in the RBD status output is parsed as 192.168.39.137
+func (r RBDStatus) GetWatcherIPs() []string {
+	watcherIPList := []string{}
+	for _, watcher := range r.Watchers {
+		watcherIP := strings.Split(watcher.Address, ":0")[0]
+		watcherIPList = append(watcherIPList, watcherIP)
+	}
+	return watcherIPList
+}
+
+// GetRBDImageStatus returns the status of the RDB image.
+func GetRBDImageStatus(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, imageName, namespace string) (RBDStatus, error) {
+	args := []string{"status", getImageSpec(imageName, poolName)}
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
+	var rbdStatusObj RBDStatus
+	cmd := NewRBDCommand(context, clusterInfo, args)
+	cmd.JsonOutput = true
+	buf, err := cmd.Run()
+	if err != nil {
+		return rbdStatusObj, errors.Wrapf(err, "failed to get status of the image %q in cephblockpool %q", imageName, poolName)
+	}
+
+	err = json.Unmarshal(buf, &rbdStatusObj)
+	if err != nil {
+		return rbdStatusObj, errors.Wrap(err, "failed to unmarshal rbd status output")
+	}
+
+	return rbdStatusObj, nil
 }

--- a/pkg/daemon/ceph/client/image_test.go
+++ b/pkg/daemon/ceph/client/image_test.go
@@ -271,3 +271,23 @@ func TestListImageLogLevelDebug(t *testing.T) {
 	assert.True(t, listCalled)
 	listCalled = false
 }
+
+func TestGetWatcherIPs(t *testing.T) {
+	rbdStatus := RBDStatus{
+		Watchers: []struct {
+			Address string "json:\"address\""
+		}{
+			{
+				Address: "192.168.39.137:0/3762982934",
+			},
+			{
+				Address: "192.168.39.136:0/3762982934",
+			},
+		},
+	}
+
+	res := rbdStatus.GetWatcherIPs()
+	assert.Equal(t, 2, len(res))
+	assert.Equal(t, "192.168.39.137", res[0])
+	assert.Equal(t, "192.168.39.136", res[1])
+}

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -466,3 +466,13 @@ func GetOSDMetadata(context *clusterd.Context, clusterInfo *ClusterInfo) (*[]OSD
 	}
 	return &osdMetadata, nil
 }
+
+// BlocklistIP blocklists the IP for predefined duration
+func BlocklistIP(context *clusterd.Context, clusterInfo *ClusterInfo, ip, duration string) error {
+	args := []string{"osd", "blocklist", "add", ip, duration}
+	_, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		return errors.Wrapf(err, "failed to blockist IP %q", ip)
+	}
+	return nil
+}


### PR DESCRIPTION
When force-deletion annotation is added to CephRadosNamespace CR, then blocklist any watchers on the Namespace images in order to remove the image from the trash


(cherry picked from commit 98475e847ed94cda2804b20116ccf95858206c5b)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
