### PR TITLE
operator: add memory, cpu request and limit values

### DIFF
--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -1502,7 +1502,13 @@ spec:
                             fieldPath: metadata.namespace
                     image: docker.io/rook/ceph:v1.17.0.29.g2348ff689
                     name: rook-ceph-operator
-                    resources: {}
+                    resources:
+                      limits:
+                        cpu: "1"
+                        memory: 512Mi
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi
                     securityContext:
                       runAsGroup: 2016
                       runAsNonRoot: true

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -815,13 +815,13 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
 
-          # Recommended resource requests and limits, if desired
-          #resources:
-          #  limits:
-          #    memory: 512Mi
-          #  requests:
-          #    cpu: 100m
-          #    memory: 128Mi
+          resources:
+            limits:
+              cpu: 1
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
 
           #  Uncomment it to run lib bucket provisioner in multithreaded mode
           #- name: LIB_BUCKET_PROVISIONER_THREADS


### PR DESCRIPTION
Add memory, cpu request and limit values to operator deployment.
The values ranged as below:
- Memory: 70Mi - 215Mi
- CPU: 110m - 670m (this high value was recorded only once, and was not consistent and mostly ranged at ~120, with one instance of 250)

Ref: https://issues.redhat.com/browse/RHSTOR-6329