### PR TITLE
DFBUGS-1501: [4.17]Allow one healthy OSD to be drained. 

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -97,9 +97,6 @@ For more details on the mons and when to choose a number other than `3`, see the
 * `disruptionManagement`: The section for configuring management of daemon disruptions
     * `managePodBudgets`: if `true`, the operator will create and manage PodDisruptionBudgets for OSD, Mon, RGW, and MDS daemons. OSD PDBs are managed dynamically via the strategy outlined in the [design](https://github.com/rook/rook/blob/master/design/ceph/ceph-managed-disruptionbudgets.md). The operator will block eviction of OSDs by default and unblock them safely when drains are detected.
     * `osdMaintenanceTimeout`: is a duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the default DOWN/OUT interval) when it is draining. The default value is `30` minutes.
-    * `pgHealthCheckTimeout`: A duration in minutes that the operator will wait for the placement groups to become healthy (see `pgHealthyRegex`) after a drain was completed and OSDs came back up.
-    Operator will continue with the next drain if the timeout exceeds.
-    No values or `0` means that the operator will wait until the placement groups are healthy before unblocking the next drain.
     * `pgHealthyRegex`: The regular expression that is used to determine which PG states should be considered healthy.
     The default is `^(active\+clean|active\+clean\+scrubbing|active\+clean\+scrubbing\+deep)$`.
 * `removeOSDsIfOutAndSafeToRemove`: If `true` the operator will remove the OSDs that are down and whose data has been restored to other OSDs. In Ceph terms, the OSDs are `out` and `safe-to-destroy` when they are removed.

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -5580,10 +5580,7 @@ time.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups to become
-healthy (active+clean) after a drain was completed and OSDs came back up. Rook will continue with the next drain
-if the timeout exceeds. It only works if managePodBudgets is true.
-No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.</p>
+<p>DEPRECATED: PGHealthCheckTimeout is no longer implemented</p>
 </td>
 </tr>
 <tr>

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -388,10 +388,6 @@ cephClusterSpec:
     # A duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the
     # default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true`. The default value is `30` minutes.
     osdMaintenanceTimeout: 30
-    # A duration in minutes that the operator will wait for the placement groups to become healthy (active+clean) after a drain was completed and OSDs came back up.
-    # Operator will continue with the next drain if the timeout exceeds. It only works if `managePodBudgets` is `true`.
-    # No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
-    pgHealthCheckTimeout: 0
 
   # Configure the healthcheck and liveness probes for ceph pods.
   # Valid values for daemons are 'mon', 'osd', 'status'

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -1174,11 +1174,7 @@ spec:
                       format: int64
                       type: integer
                     pgHealthCheckTimeout:
-                      description: |-
-                        PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups to become
-                        healthy (active+clean) after a drain was completed and OSDs came back up. Rook will continue with the next drain
-                        if the timeout exceeds. It only works if managePodBudgets is true.
-                        No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
+                      description: 'DEPRECATED: PGHealthCheckTimeout is no longer implemented'
                       format: int64
                       type: integer
                     pgHealthyRegex:

--- a/deploy/examples/cluster-on-local-pvc.yaml
+++ b/deploy/examples/cluster-on-local-pvc.yaml
@@ -256,4 +256,3 @@ spec:
   disruptionManagement:
     managePodBudgets: true
     osdMaintenanceTimeout: 30
-    pgHealthCheckTimeout: 0

--- a/deploy/examples/cluster-on-pvc-minikube.yaml
+++ b/deploy/examples/cluster-on-pvc-minikube.yaml
@@ -187,7 +187,6 @@ spec:
   disruptionManagement:
     managePodBudgets: true
     osdMaintenanceTimeout: 30
-    pgHealthCheckTimeout: 0
   cephConfig:
     global:
       mon_warn_on_pool_no_redundancy: "false"

--- a/deploy/examples/cluster-on-pvc.yaml
+++ b/deploy/examples/cluster-on-pvc.yaml
@@ -181,7 +181,6 @@ spec:
   disruptionManagement:
     managePodBudgets: true
     osdMaintenanceTimeout: 30
-    pgHealthCheckTimeout: 0
   # security oriented settings
   # security:
   # Settings to enable key rotation for KEK(Key Encryption Key).

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -295,10 +295,6 @@ spec:
     # A duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the
     # default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true`. The default value is `30` minutes.
     osdMaintenanceTimeout: 30
-    # A duration in minutes that the operator will wait for the placement groups to become healthy (active+clean) after a drain was completed and OSDs came back up.
-    # Operator will continue with the next drain if the timeout exceeds. It only works if `managePodBudgets` is `true`.
-    # No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
-    pgHealthCheckTimeout: 0
 
   # csi defines CSI Driver settings applied per cluster.
   csi:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -1172,11 +1172,7 @@ spec:
                       format: int64
                       type: integer
                     pgHealthCheckTimeout:
-                      description: |-
-                        PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups to become
-                        healthy (active+clean) after a drain was completed and OSDs came back up. Rook will continue with the next drain
-                        if the timeout exceeds. It only works if managePodBudgets is true.
-                        No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
+                      description: 'DEPRECATED: PGHealthCheckTimeout is no longer implemented'
                       format: int64
                       type: integer
                     pgHealthyRegex:

--- a/design/ceph/ceph-managed-disruptionbudgets.md
+++ b/design/ceph/ceph-managed-disruptionbudgets.md
@@ -16,13 +16,25 @@ OSDs do not fit under the single PodDisruptionBudget pattern. Ceph's ability to 
 Even if an upgrade agent were only to drain one node at a time, Ceph would have to wait until there were no undersized PGs before moving on the next.
 
 The failure domain will be determined by the smallest failure domain of all the Ceph Pools in that cluster.
-We begin with creating a single PodDisruptionBudget for all the OSD with maxUnavailable=1. This will allow one OSD to go down anytime. Once the user drains a node and an OSD goes down, we determine the failure domain for the draining OSD (using the OSD deployment labels). Then we create blocking PodDisruptionBudgets (maxUnavailable=0) for all other failure domains and delete the main PodDisruptionBudget. This blocks OSDs from going down in multiple failure domains simultaneously.
 
-Once the drained OSDs are back and all the pgs are active+clean, that is, the cluster is healed, the default PodDisruptionBudget (with maxUnavailable=1) is added back and the blocking ones are deleted. User can also add a timeout for the pgs to become healthy. If the timeout exceeds, the operator will ignore the pg health, add the main PodDisruptionBudget and delete the blocking ones.
+#### Types of OSD PDBs:
+- `Default` PDB:
+    - Named as `rook-ceph-osd`
+    - It allows one healthy OSD to go down, by setting `maxUnavailable=1`, on any failure domain.
+    - Sometimes one or more OSDs can be down (disk failure, etc) without any node drain but PGs would still be `active+clean`. In that case, the `maxUnavailable` is set to `1+number of down OSDs`
+- `Blocking` PDBs
+    - Named as `rook-ceph-osd-<failureDomainType>-<FailureDomainName>`. For example: `rook-ceph-osd-zone-zone-a`
+    - These PDBs are created on the entire failure domain.
+    - `maxUnavailable` is set to 0 to prevent any OSD pod from draining.
 
-Detecting drains is not easy as they are a client side operation. The client cordons the node and continuously attempts to evict all pods from the node until it succeeds. Whenever an OSD goes into pending state, that is, `ReadyReplicas` count is 0, we assume that some drain operation is happening.
+We begin with creating the default PodDisruptionBudget for all the OSDs. Once the user drains a node and an OSD goes down, we determine the failure domain for the draining OSD (using the OSD deployment labels). Then we create blocking PodDisruptionBudgets (maxUnavailable=0) for all other failure domains and delete the main PodDisruptionBudget. This blocks OSDs from going down in multiple failure domains simultaneously.
 
-Example scenario:
+Once the drained OSDs are back and all the pgs are active+clean, that is, the cluster is healed, the default PodDisruptionBudget is added back and the blocking ones are deleted.
+
+#### Detecting Node Drains:
+Detecting drains is not easy as they are a client side operation. The client cordons the node and continuously attempts to evict all pods from the node until it succeeds. If a node on which the OSD is suppose to run, is `unscheduleable` then the operator considers that node to be draining.
+
+#### Example scenario:
 
 - Zone x
   - Node a
@@ -37,22 +49,31 @@ Example scenario:
     - osd.4
     - osd.5
 
-1. Rook Operator creates a single PDB that covers all OSDs with maxUnavailable=1.
-2. When Rook Operator sees an OSD go down (for example, osd.0 goes down):
-   - Create a PDB for each failure domain (zones y and z) with maxUnavailable=0 where the OSD did *not* go down.
-   - Delete the original PDB that covers all OSDs
+1. A default PDB `rook-ceph-osd`, with maxUnavailable=1, is created for all OSDs.
+2. User drains `Node a` for maintenance
+3. Operator notices that an OSD has gone down (for example, `osd.0` on `Node a` and `Zone x`):
+   - Creates a blocking PDBs `rook-ceph-osd-zone-zone-y` and `rook-ceph-osd-zone-zone-z`
+   - Deletes the default PDB that covers all OSDs
    - Now all remaining OSDs in zone x would be allowed to be drained
-3. When Rook sees the OSDs are back up and all PGs are clean
-   - Restore the PDB that covers all OSDs with maxUnavailable=1
-   - Delete the PDBs (in zone y and z) where maxUnavailable=0
+4. When `Node-a` is back, all of its OSDs are running and all PGs are `active+clean`:
+   - Restores the default PDB `rook-ceph-osd` (maxUnavailable=1)
+   - Deletes the blocking PDBs `rook-ceph-osd-zone-zone-y` and `rook-ceph-osd-zone-zone-z`
 
 An example of an operator that will attempt to do rolling upgrades of nodes is the Machine Config Operator in openshift. Based on what I have seen in
 [SIG cluster lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle), kubernetes deployments based on cluster-api approach will be
 a common way of deploying kubernetes. This will also work to mitigate manual drains from accidentally disrupting storage.
 
-When an node is drained, we will also delay it's DOWN/OUT process by placing a noout on that node. We will remove that noout after a timeout.
 
-An OSD can be down due to reasons other than node drain, say, disk failure. In such a situation, if the pgs are unhealthy then rook will create a blocking PodDisruptionBudget on other failure domains to prevent further node drains on them. `noout` flag won't be set on node this is case. If the OSD is down but all the pgs are `active+clean`, the cluster will be treated as fully healthy. The default PodDisruptionBudget (with maxUnavailable=1) will be added back and the blocking ones will be deleted.
+#### Preventing unnecessary data migration:
+- If a node is down due to planned maintenance, we don't want the data of the drained OSDs to be migrated to other OSDs.
+- Operator adds `noout` flag to the failure domain on which the node was drained.
+- This `noout` is removed after `OSDMaintenanceTimeout` is elapsed. `OSDMaintenanceTimeout` defaults to 30 minutes but can be configured from the cephCluster CR.
+- `noout` is not added if the OSD is down but there is no node drain.
+
+#### OSDs down due to reasons other than node drain:
+- OSDs can be down due to various reasons other than a node drain event. For example, disk failure.
+- If the PGs are active+clean even after the OSDs are down, then the operator will update the `maxUnavailable` count to `1+number of down OSDs` in the main PDB.
+- This will allow other healthy OSDs to be drained.
 
 ### Mon, Mgr, MDS, RGW, RBDMirror
 

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2696,10 +2696,7 @@ type DisruptionManagementSpec struct {
 	// +optional
 	OSDMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
 
-	// PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups to become
-	// healthy (active+clean) after a drain was completed and OSDs came back up. Rook will continue with the next drain
-	// if the timeout exceeds. It only works if managePodBudgets is true.
-	// No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
+	// DEPRECATED: PGHealthCheckTimeout is no longer implemented
 	// +optional
 	PGHealthCheckTimeout time.Duration `json:"pgHealthCheckTimeout,omitempty"`
 

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -448,3 +448,22 @@ func SetPrimaryAffinity(context *clusterd.Context, clusterInfo *ClusterInfo, osd
 	logger.Infof("successfully applied osd.%d primary-affinity %q", osdID, affinity)
 	return nil
 }
+
+type OSDMetadata struct {
+	Id       int    `json:"id"`
+	HostName string `json:"hostname"`
+}
+
+// GetOSDMetadata returns the output of `ceph osd metadata`
+func GetOSDMetadata(context *clusterd.Context, clusterInfo *ClusterInfo) (*[]OSDMetadata, error) {
+	args := []string{"osd", "metadata"}
+	buf, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get osd metadata")
+	}
+	var osdMetadata []OSDMetadata
+	if err := json.Unmarshal(buf, &osdMetadata); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal osd metadata response")
+	}
+	return &osdMetadata, nil
+}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -570,7 +570,8 @@ func (c *Cluster) getPVCHostName(pvcName string) (string, error) {
 	return "", errors.Errorf("node selector not found on deployment for osd with pvc %q", pvcName)
 }
 
-func getOSDID(d *appsv1.Deployment) (int, error) {
+// GetOSDID returns OSD ID from the OSD deployment
+func GetOSDID(d *appsv1.Deployment) (int, error) {
 	osdID, err := strconv.Atoi(d.Labels[OsdIdLabelKey])
 	if err != nil {
 		// add a question to the user AFTER the error text to help them recover from user error
@@ -583,7 +584,7 @@ func (c *Cluster) getOSDInfo(d *appsv1.Deployment) (OSDInfo, error) {
 	container := d.Spec.Template.Spec.Containers[0]
 	var osd OSDInfo
 
-	osdID, err := getOSDID(d)
+	osdID, err := GetOSDID(d)
 	if err != nil {
 		return OSDInfo{}, err
 	}

--- a/pkg/operator/ceph/cluster/osd/update.go
+++ b/pkg/operator/ceph/cluster/osd/update.go
@@ -236,7 +236,7 @@ func (c *Cluster) getOSDUpdateInfo(errs *provisionErrors) (*updateQueue, *existe
 	updateQueue := newUpdateQueueWithCapacity(len(deps.Items))
 	existenceList := newExistenceListWithCapacity(len(deps.Items))
 	for i := range deps.Items {
-		id, err := getOSDID(&deps.Items[i]) // avoid implicit memory aliasing by indexing
+		id, err := GetOSDID(&deps.Items[i]) // avoid implicit memory aliasing by indexing
 		if err != nil {
 			// add a question to the user AFTER the error text to help them recover from user error
 			errs.addError("%v. did a user create their own deployment with label %q?", selector, err)

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -268,7 +268,6 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 				maxUnavailableOSDCount = 1
 			} else {
 				maxUnavailableOSDCount = len(downOSDs) + 1
-				resetPDBConfig(pdbStateMap)
 			}
 		} else {
 			maxUnavailableOSDCount = len(downOSDs) + 1

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -47,25 +46,19 @@ const (
 	healthyCephStatusRemapped = `{"fsid":"e32d91a2-24ff-4953-bc4a-6864d31dd2a0","health":{"status":"HEALTH_OK","checks":{},"mutes":[]},"election_epoch":3,"quorum":[0],"quorum_names":["a"],"quorum_age":1177701,"monmap":{"epoch":1,"min_mon_release_name":"quincy","num_mons":1},"osdmap":{"epoch":1800,"num_osds":5,"num_up_osds":5,"osd_up_since":1699834324,"num_in_osds":5,"osd_in_since":1699834304,"num_remapped_pgs":11},"pgmap":{"pgs_by_state":[{"state_name":"active+clean","count":174},{"state_name":"active+remapped+backfilling","count":10},{"state_name":"active+clean+remapped","count":1}],"num_pgs":185,"num_pools":9,"num_objects":2383,"data_bytes":2222656224,"bytes_used":8793104384,"bytes_avail":18050441216,"bytes_total":26843545600,"misplaced_objects":139,"misplaced_total":7149,"misplaced_ratio":0.019443278780248985,"recovering_objects_per_sec":10,"recovering_bytes_per_sec":9739877,"recovering_keys_per_sec":0,"num_objects_recovered":62,"num_bytes_recovered":58471087,"num_keys_recovered":0,"write_bytes_sec":2982994,"read_op_per_sec":0,"write_op_per_sec":26},"fsmap":{"epoch":1,"by_rank":[],"up:standby":0},"mgrmap":{"available":true,"num_standbys":0,"modules":["iostat","nfs","prometheus","restful"],"services":{"prometheus":"http://10.244.0.36:9283/"}},"servicemap":{"epoch":1,"modified":"0.000000","services":{}},"progress_events":{}}`
 )
 
-var nodeName = "node01"
 var namespace = "rook-ceph"
 
 var cephCluster = &cephv1.CephCluster{
 	ObjectMeta: metav1.ObjectMeta{Name: "ceph-cluster"},
 }
 
-var nodeObj = &corev1.Node{
-	ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-	Spec: corev1.NodeSpec{
-		Unschedulable: false,
-	},
-}
-
-var unschedulableNodeObj = &corev1.Node{
-	ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-	Spec: corev1.NodeSpec{
-		Unschedulable: true,
-	},
+func getNodeObject(name string, unschedulable bool) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.NodeSpec{
+			Unschedulable: unschedulable,
+		},
+	}
 }
 
 func fakeOSDDeployment(id, readyReplicas int) appsv1.Deployment {
@@ -74,17 +67,9 @@ func fakeOSDDeployment(id, readyReplicas int) appsv1.Deployment {
 			Name:      fmt.Sprintf("osd-%d", id),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app": "rook-ceph-osd",
-			},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"topology-location-zone": fmt.Sprintf("zone-%d", id),
-						"ceph-osd-id":            fmt.Sprintf("%d", id),
-					},
-				},
+				"app":                    "rook-ceph-osd",
+				"topology-location-zone": fmt.Sprintf("zone-%d", id),
+				"ceph-osd-id":            fmt.Sprintf("%d", id),
 			},
 		},
 		Status: appsv1.DeploymentStatus{
@@ -92,23 +77,6 @@ func fakeOSDDeployment(id, readyReplicas int) appsv1.Deployment {
 		},
 	}
 	return osd
-}
-
-func fakeOSDPod(id int, nodeName string) corev1.Pod {
-	osdPod := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("osd-%d", id),
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app":         "rook-ceph-osd",
-				"ceph-osd-id": fmt.Sprintf("%d", id),
-			},
-		},
-		Spec: corev1.PodSpec{
-			NodeName: nodeName,
-		},
-	}
-	return osdPod
 }
 
 func fakePDBConfigMap(drainingFailureDomain string) *corev1.ConfigMap {
@@ -147,66 +115,62 @@ func TestGetOSDFailureDomains(t *testing.T) {
 	testcases := []struct {
 		name                           string
 		osds                           []appsv1.Deployment
-		osdPods                        []corev1.Pod
-		node                           *corev1.Node
+		osdMetadata                    string
+		nodes                          []corev1.Node
 		expectedAllFailureDomains      []string
 		expectedDrainingFailureDomains []string
 		expectedOsdDownFailureDomains  []string
+		expectedDownOSDs               []int
 	}{
 		{
 			name: "case 1: all osds are running",
 			osds: []appsv1.Deployment{fakeOSDDeployment(1, 1), fakeOSDDeployment(2, 1),
 				fakeOSDDeployment(3, 1)},
-			osdPods: []corev1.Pod{fakeOSDPod(1, nodeName), fakeOSDPod(2, nodeName),
-				fakeOSDPod(3, nodeName)},
-			node:                           nodeObj,
+			nodes:                          []corev1.Node{*getNodeObject("node-1", false), *getNodeObject("node-2", false), *getNodeObject("node-3", false)},
 			expectedAllFailureDomains:      []string{"zone-1", "zone-2", "zone-3"},
 			expectedOsdDownFailureDomains:  []string{},
 			expectedDrainingFailureDomains: []string{},
+			expectedDownOSDs:               []int{},
 		},
 		{
 			name: "case 2: osd in zone-1 is pending and node is unschedulable",
 			osds: []appsv1.Deployment{fakeOSDDeployment(1, 0), fakeOSDDeployment(2, 1),
 				fakeOSDDeployment(3, 1)},
-			osdPods: []corev1.Pod{fakeOSDPod(1, ""), fakeOSDPod(2, nodeName),
-				fakeOSDPod(3, nodeName)},
-			node:                           nodeObj,
+			nodes:                          []corev1.Node{*getNodeObject("node-1", true), *getNodeObject("node-2", false), *getNodeObject("node-3", false)},
 			expectedAllFailureDomains:      []string{"zone-1", "zone-2", "zone-3"},
 			expectedOsdDownFailureDomains:  []string{"zone-1"},
 			expectedDrainingFailureDomains: []string{"zone-1"},
+			expectedDownOSDs:               []int{1},
 		},
 		{
 			name: "case 3: osd in zone-1 and zone-2 are pending and node is unschedulable",
 			osds: []appsv1.Deployment{fakeOSDDeployment(1, 0), fakeOSDDeployment(2, 0),
 				fakeOSDDeployment(3, 1)},
-			osdPods: []corev1.Pod{fakeOSDPod(1, ""), fakeOSDPod(2, ""),
-				fakeOSDPod(3, nodeName)},
-			node:                           nodeObj,
+			nodes:                          []corev1.Node{*getNodeObject("node-1", true), *getNodeObject("node-2", true), *getNodeObject("node-3", false)},
 			expectedAllFailureDomains:      []string{"zone-1", "zone-2", "zone-3"},
 			expectedOsdDownFailureDomains:  []string{"zone-1", "zone-2"},
 			expectedDrainingFailureDomains: []string{"zone-1", "zone-2"},
+			expectedDownOSDs:               []int{1, 2},
 		},
 		{
 			name: "case 4: osd in zone-1 is pending but osd node is schedulable",
 			osds: []appsv1.Deployment{fakeOSDDeployment(1, 0), fakeOSDDeployment(2, 1),
 				fakeOSDDeployment(3, 1)},
-			osdPods: []corev1.Pod{fakeOSDPod(1, nodeName), fakeOSDPod(2, nodeName),
-				fakeOSDPod(3, nodeName)},
-			node:                           nodeObj,
+			nodes:                          []corev1.Node{*getNodeObject("node-1", false), *getNodeObject("node-2", false), *getNodeObject("node-3", false)},
 			expectedAllFailureDomains:      []string{"zone-1", "zone-2", "zone-3"},
 			expectedOsdDownFailureDomains:  []string{"zone-1"},
 			expectedDrainingFailureDomains: []string{},
+			expectedDownOSDs:               []int{1},
 		},
 		{
-			name: "case 5: osd in zone-1 is pending but osd node is not schedulable",
-			osds: []appsv1.Deployment{fakeOSDDeployment(1, 0), fakeOSDDeployment(2, 1),
-				fakeOSDDeployment(3, 1)},
-			osdPods: []corev1.Pod{fakeOSDPod(1, nodeName), fakeOSDPod(2, nodeName),
-				fakeOSDPod(3, nodeName)},
-			node:                           unschedulableNodeObj,
+			name: "case 5: osd in zone-3 is pending and the osd node is not schedulable",
+			osds: []appsv1.Deployment{fakeOSDDeployment(1, 1), fakeOSDDeployment(2, 1),
+				fakeOSDDeployment(3, 0)},
+			nodes:                          []corev1.Node{*getNodeObject("node-1", false), *getNodeObject("node-2", false), *getNodeObject("node-3", true)},
 			expectedAllFailureDomains:      []string{"zone-1", "zone-2", "zone-3"},
-			expectedOsdDownFailureDomains:  []string{"zone-1"},
-			expectedDrainingFailureDomains: []string{"zone-1"},
+			expectedOsdDownFailureDomains:  []string{"zone-3"},
+			expectedDrainingFailureDomains: []string{"zone-3"},
+			expectedDownOSDs:               []int{3},
 		},
 	}
 
@@ -215,23 +179,34 @@ func TestGetOSDFailureDomains(t *testing.T) {
 			objs := []runtime.Object{
 				cephCluster,
 				&corev1.ConfigMap{},
-				tc.node,
+			}
+			for _, node := range tc.nodes {
+				objs = append(objs, node.DeepCopy())
 			}
 			for _, osdDeployment := range tc.osds {
 				objs = append(objs, osdDeployment.DeepCopy())
 			}
-			for _, osdPod := range tc.osdPods {
-				objs = append(objs, osdPod.DeepCopy())
+
+			executor := &exectest.MockExecutor{}
+			executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+				logger.Infof("Command: %s %v", command, args)
+				if args[0] == "osd" && args[1] == "metadata" {
+					return `[{"id": 1, "hostname": "node-1"}, {"id": 2, "hostname": "node-2"}, {"id": 3, "hostname": "node-3"}]`, nil
+				}
+				return "", errors.Errorf("unexpected ceph command '%v'", args)
 			}
+
 			r := getFakeReconciler(t, objs...)
 			clusterInfo := getFakeClusterInfo()
 			clusterInfo.Context = context.TODO()
+			r.context = &controllerconfig.Context{ClusterdContext: &clusterd.Context{Executor: executor}}
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
-			allfailureDomains, nodeDrainFailureDomains, osdDownFailureDomains, err := r.getOSDFailureDomains(clusterInfo, request, "zone")
+			allfailureDomains, nodeDrainFailureDomains, osdDownFailureDomains, downOSDs, err := r.getOSDFailureDomains(clusterInfo, request, "zone")
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedAllFailureDomains, allfailureDomains)
 			assert.Equal(t, tc.expectedDrainingFailureDomains, nodeDrainFailureDomains)
 			assert.Equal(t, tc.expectedOsdDownFailureDomains, osdDownFailureDomains)
+			assert.Equal(t, tc.expectedDownOSDs, downOSDs)
 		})
 	}
 }
@@ -243,6 +218,7 @@ func TestGetOSDFailureDomainsError(t *testing.T) {
 		expectedAllFailureDomains      []string
 		expectedDrainingFailureDomains []string
 		expectedOsdDownFailureDomains  []string
+		expectedDownOSDs               []int
 	}{
 		{
 			name: "case 1: one or more OSD deployment is missing crush location label",
@@ -251,23 +227,34 @@ func TestGetOSDFailureDomainsError(t *testing.T) {
 			expectedAllFailureDomains:      nil,
 			expectedDrainingFailureDomains: nil,
 			expectedOsdDownFailureDomains:  nil,
+			expectedDownOSDs:               nil,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			executor := &exectest.MockExecutor{}
+			executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+				logger.Infof("Command: %s %v", command, args)
+				if args[0] == "osd" && args[1] == "metadata" {
+					return `[{"id": 1, "hostname": "node-1"}, {"id": 2, "hostname": "node-2"}, {"id": 3, "hostname": "node-3"}]`, nil
+				}
+				return "", errors.Errorf("unexpected ceph command '%v'", args)
+			}
 			osd := tc.osds[0].DeepCopy()
-			osd.Spec.Template.ObjectMeta.Labels["topology-location-zone"] = ""
+			osd.Labels["topology-location-zone"] = ""
 			r := getFakeReconciler(t, cephCluster, &corev1.ConfigMap{},
 				tc.osds[1].DeepCopy(), tc.osds[2].DeepCopy(), osd)
+			r.context = &controllerconfig.Context{ClusterdContext: &clusterd.Context{Executor: executor}}
 			clusterInfo := getFakeClusterInfo()
 			clusterInfo.Context = context.TODO()
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
-			allfailureDomains, nodeDrainFailureDomains, osdDownFailureDomains, err := r.getOSDFailureDomains(clusterInfo, request, "zone")
+			allfailureDomains, nodeDrainFailureDomains, osdDownFailureDomains, downOSDs, err := r.getOSDFailureDomains(clusterInfo, request, "zone")
 			assert.Error(t, err)
 			assert.Equal(t, tc.expectedAllFailureDomains, allfailureDomains)
 			assert.Equal(t, tc.expectedDrainingFailureDomains, nodeDrainFailureDomains)
 			assert.Equal(t, tc.expectedOsdDownFailureDomains, osdDownFailureDomains)
+			assert.Equal(t, tc.expectedDownOSDs, downOSDs)
 		})
 	}
 }
@@ -276,11 +263,11 @@ func TestReconcilePDBForOSD(t *testing.T) {
 	testcases := []struct {
 		name                              string
 		fakeCephStatus                    string
-		fakeOSDDump                       string
 		configMap                         *corev1.ConfigMap
 		allFailureDomains                 []string
 		osdDownFailureDomains             []string
-		activeNodeDrains                  bool
+		activeNodeDrains                  []string
+		downOSDs                          []int
 		pgHealthyRegex                    string
 		expectedSetNoOutValue             string
 		expectedOSDPDBCount               int
@@ -288,13 +275,13 @@ func TestReconcilePDBForOSD(t *testing.T) {
 		expectedDrainingFailureDomainName string
 	}{
 		{
-			name:                              "case 1: no draining failure domain and all pgs are healthy",
+			name:                              "case 1: No draining failure domains, all OSDs are up/in and all pgs are healthy",
 			fakeCephStatus:                    healthyCephStatus,
-			fakeOSDDump:                       `{"OSDs": [{"OSD": 3, "Up": 3, "In": 3}]}`,
 			allFailureDomains:                 []string{"zone-1", "zone-2", "zone-3"},
 			osdDownFailureDomains:             []string{},
+			downOSDs:                          []int{},
+			activeNodeDrains:                  []string{},
 			configMap:                         fakePDBConfigMap(""),
-			activeNodeDrains:                  false,
 			pgHealthyRegex:                    "",
 			expectedSetNoOutValue:             "",
 			expectedOSDPDBCount:               1,
@@ -304,11 +291,11 @@ func TestReconcilePDBForOSD(t *testing.T) {
 		{
 			name:                              "case 2: zone-1 failure domain is draining and pgs are unhealthy",
 			fakeCephStatus:                    unHealthyCephStatus,
-			fakeOSDDump:                       `{"OSDs": [{"OSD": 3, "Up": 3, "In": 2}]}`,
 			allFailureDomains:                 []string{"zone-1", "zone-2", "zone-3"},
 			osdDownFailureDomains:             []string{"zone-1"},
+			downOSDs:                          []int{1},
 			configMap:                         fakePDBConfigMap(""),
-			activeNodeDrains:                  true,
+			activeNodeDrains:                  []string{"zone-1"},
 			pgHealthyRegex:                    "",
 			expectedSetNoOutValue:             "true",
 			expectedOSDPDBCount:               2,
@@ -318,11 +305,11 @@ func TestReconcilePDBForOSD(t *testing.T) {
 		{
 			name:                              "case 3: zone-1 is back online. But pgs are still unhealthy from zone-1 drain",
 			fakeCephStatus:                    unHealthyCephStatus,
-			fakeOSDDump:                       `{"OSDs": [{"OSD": 3, "Up": 3, "In": 3}]}`,
 			allFailureDomains:                 []string{"zone-1", "zone-2", "zone-3"},
 			osdDownFailureDomains:             []string{},
+			downOSDs:                          []int{},
 			configMap:                         fakePDBConfigMap("zone-1"),
-			activeNodeDrains:                  true,
+			activeNodeDrains:                  []string{},
 			pgHealthyRegex:                    "",
 			expectedSetNoOutValue:             "",
 			expectedOSDPDBCount:               2,
@@ -332,11 +319,11 @@ func TestReconcilePDBForOSD(t *testing.T) {
 		{
 			name:                              "case 4: zone-1 is back online and pgs are also healthy",
 			fakeCephStatus:                    healthyCephStatus,
-			fakeOSDDump:                       `{"OSDs": [{"OSD": 3, "Up": 3, "In": 3}]}`,
 			allFailureDomains:                 []string{"zone-1", "zone-2", "zone-3"},
 			osdDownFailureDomains:             []string{},
+			downOSDs:                          []int{},
 			configMap:                         fakePDBConfigMap("zone-1"),
-			activeNodeDrains:                  true,
+			activeNodeDrains:                  []string{},
 			pgHealthyRegex:                    "",
 			expectedSetNoOutValue:             "",
 			expectedOSDPDBCount:               1,
@@ -346,15 +333,30 @@ func TestReconcilePDBForOSD(t *testing.T) {
 		{
 			name:                              "case 5: remapped pgs are regarded as clean if pgHealthyRegex allows it",
 			fakeCephStatus:                    healthyCephStatusRemapped,
-			fakeOSDDump:                       `{"OSDs": [{"OSD": 3, "Up": 3, "In": 3}]}`,
 			allFailureDomains:                 []string{"zone-1", "zone-2", "zone-3"},
 			osdDownFailureDomains:             []string{},
+			downOSDs:                          []int{},
 			configMap:                         fakePDBConfigMap("zone-1"),
-			activeNodeDrains:                  true,
+			activeNodeDrains:                  []string{},
 			pgHealthyRegex:                    `^(active\+clean|active\+clean\+scrubbing|active\+clean\+scrubbing\+deep|active\+clean\+remapped|active\+remapped\+backfilling)$`,
 			expectedSetNoOutValue:             "",
 			expectedOSDPDBCount:               1,
 			expectedMaxUnavailableCount:       1,
+			expectedDrainingFailureDomainName: "",
+		},
+		{
+			name:                  "case 6: Cluster is healthy but OSDs are down. MaxUnavailable should be set to 1 + number of down OSDs",
+			fakeCephStatus:        healthyCephStatus,
+			allFailureDomains:     []string{"zone-1", "zone-2", "zone-3"},
+			osdDownFailureDomains: []string{},
+			// OSD 0 and 1 are down but ceph health is good. So maxUnavailable should be set to 3.
+			downOSDs:                          []int{0, 1},
+			configMap:                         fakePDBConfigMap("zone-1"),
+			activeNodeDrains:                  []string{},
+			pgHealthyRegex:                    "",
+			expectedSetNoOutValue:             "",
+			expectedOSDPDBCount:               1,
+			expectedMaxUnavailableCount:       3,
 			expectedDrainingFailureDomainName: "",
 		},
 	}
@@ -372,7 +374,7 @@ func TestReconcilePDBForOSD(t *testing.T) {
 					return tc.fakeCephStatus, nil
 				}
 				if args[0] == "osd" && args[1] == "dump" {
-					return tc.fakeOSDDump, nil
+					return `{"OSDs": [{"OSD": 3, "Up": 3, "In": 3}]}`, nil
 				}
 				return "", errors.Errorf("unexpected ceph command '%v'", args)
 			}
@@ -381,7 +383,8 @@ func TestReconcilePDBForOSD(t *testing.T) {
 			// check for PDBV1 version
 			test.SetFakeKubernetesVersion(clientset, "v1.21.0")
 			r.context = &controllerconfig.Context{ClusterdContext: &clusterd.Context{Executor: executor, Clientset: clientset}}
-			_, err := r.reconcilePDBsForOSDs(clusterInfo, request, tc.configMap, "zone", tc.allFailureDomains, tc.osdDownFailureDomains, tc.activeNodeDrains, tc.pgHealthyRegex)
+
+			_, err := r.reconcilePDBsForOSDs(clusterInfo, request, tc.configMap, "zone", tc.allFailureDomains, tc.osdDownFailureDomains, tc.activeNodeDrains, tc.downOSDs, tc.pgHealthyRegex)
 			assert.NoError(t, err)
 
 			// assert that pdb for osd are created correctly
@@ -399,105 +402,75 @@ func TestReconcilePDBForOSD(t *testing.T) {
 			assert.Equal(t, tc.expectedDrainingFailureDomainName, existingConfigMaps.Items[0].Data[drainingFailureDomainKey])
 			assert.Equal(t, tc.expectedSetNoOutValue, existingConfigMaps.Items[0].Data[setNoOut])
 		})
-
 	}
-}
-
-func TestPGHealthcheckTimeout(t *testing.T) {
-	pdbConfig := fakePDBConfigMap("")
-	r := getFakeReconciler(t, cephCluster, pdbConfig)
-	clusterInfo := getFakeClusterInfo()
-	clusterInfo.Context = context.TODO()
-	request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
-	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
-		logger.Infof("Command: %s %v", command, args)
-		if args[0] == "status" {
-			return unHealthyCephStatus, nil
-		}
-		if args[0] == "osd" && args[1] == "dump" {
-			return `{"OSDs": [{"OSD": 3, "Up": 3, "In": 3}]}`, nil
-		}
-		return "", errors.Errorf("unexpected ceph command '%v'", args)
-	}
-	clientset := test.New(t, 3)
-	r.context = &controllerconfig.Context{ClusterdContext: &clusterd.Context{Executor: executor, Clientset: clientset}}
-	// set PG health check timeout to 10 minutes
-	r.pgHealthCheckTimeout = time.Duration(time.Minute * 10)
-
-	// reconcile OSD PDB with active drains (on zone-1) and unhealthy PGs
-	_, err := r.reconcilePDBsForOSDs(clusterInfo, request, pdbConfig, "zone", []string{"zone-1", "zone-2"}, []string{"zone-1"}, true, "")
-	assert.NoError(t, err)
-	assert.Equal(t, "zone-1", pdbConfig.Data[drainingFailureDomainKey])
-	assert.Equal(t, "true", pdbConfig.Data[setNoOut])
-
-	// update the pgHealthCheckDuration time by -9 minutes
-	pdbConfig.Data[pgHealthCheckDurationKey] = time.Now().Add(time.Duration(-7) * time.Minute).Format(time.RFC3339)
-	// reconcile OSD PDB with no active drains and unhealthy PGs
-	_, err = r.reconcilePDBsForOSDs(clusterInfo, request, pdbConfig, "zone", []string{"zone-1", "zone-2"}, []string{}, true, "")
-	assert.NoError(t, err)
-	// assert that pdb config map was not reset as the PG health check was not timed out
-	assert.Equal(t, "zone-1", pdbConfig.Data[drainingFailureDomainKey])
-	assert.Equal(t, "true", pdbConfig.Data[setNoOut])
-
-	// update the drainingFailureDomain time by -9 minutes
-	pdbConfig.Data[pgHealthCheckDurationKey] = time.Now().Add(time.Duration(-11) * time.Minute).Format(time.RFC3339)
-	// reconcile OSD PDB with no active drains and unhealthy PGs
-	_, err = r.reconcilePDBsForOSDs(clusterInfo, request, pdbConfig, "zone", []string{"zone-1", "zone-2"}, []string{}, false, "")
-	assert.NoError(t, err)
-	// assert that pdb config map was reset as the PG health check was timed out
-	assert.Equal(t, "", pdbConfig.Data[drainingFailureDomainKey])
-	assert.Equal(t, "", pdbConfig.Data[setNoOut])
 }
 
 func TestHasNodeDrained(t *testing.T) {
-	osdPOD := fakeOSDPod(0, nodeName)
+	osdDeployment := fakeOSDDeployment(1, 1)
 	ctx := context.TODO()
 	// Not expecting node drain because OSD pod is assigned to a schedulable node
-	r := getFakeReconciler(t, nodeObj, osdPOD.DeepCopy(), &corev1.ConfigMap{})
-	expected, err := hasOSDNodeDrained(ctx, r.client, namespace, "0")
+	r := getFakeReconciler(t, getNodeObject("node-1", false), osdDeployment.DeepCopy(), &corev1.ConfigMap{})
+	expected, err := hasOSDNodeDrained(ctx, r.client, "node-1")
 	assert.NoError(t, err)
 	assert.False(t, expected)
 
 	// Expecting node drain because OSD pod is assigned to an unschedulable node
-	r = getFakeReconciler(t, unschedulableNodeObj, osdPOD.DeepCopy(), &corev1.ConfigMap{})
-	expected, err = hasOSDNodeDrained(ctx, r.client, namespace, "0")
-	assert.NoError(t, err)
-	assert.True(t, expected)
-
-	// Expecting node drain because OSD pod is not assigned to any node
-	osdPodObj := osdPOD.DeepCopy()
-	osdPodObj.Spec.NodeName = ""
-	r = getFakeReconciler(t, nodeObj, osdPodObj, &corev1.ConfigMap{})
-	expected, err = hasOSDNodeDrained(ctx, r.client, namespace, "0")
+	osdDeployment = fakeOSDDeployment(2, 2)
+	r = getFakeReconciler(t, getNodeObject("node-2", true), osdDeployment.DeepCopy(), &corev1.ConfigMap{})
+	expected, err = hasOSDNodeDrained(ctx, r.client, "node-2")
 	assert.NoError(t, err)
 	assert.True(t, expected)
 }
 
-func TestGetAllowedDisruptions(t *testing.T) {
-	r := getFakeReconciler(t)
-	clientset := test.New(t, 3)
-	test.SetFakeKubernetesVersion(clientset, "v1.21.0")
-	r.context = &controllerconfig.Context{ClusterdContext: &clusterd.Context{Clientset: clientset}}
-
-	// Default PDB is not available
-	allowedDisruptions, err := r.getAllowedDisruptions(osdPDBAppName, namespace)
-	assert.Error(t, err)
-	assert.Equal(t, int32(-1), allowedDisruptions)
-
-	// Default PDB is available
-	pdb := &policyv1.PodDisruptionBudget{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      osdPDBAppName,
-			Namespace: namespace,
+func TestSetPDBConfig(t *testing.T) {
+	testcases := []struct {
+		name                          string
+		pdbConfig                     *corev1.ConfigMap
+		osdDownFailureDomains         []string
+		drainingFailureDomains        []string
+		expectedFailureDomainKeyValue string
+		expecteNoOutSetting           string
+	}{
+		{
+			name:                          "case 1: Empty PDB config and no draining failureDomain",
+			pdbConfig:                     fakePDBConfigMap(""),
+			osdDownFailureDomains:         []string{"zone-1", "zone-2"},
+			drainingFailureDomains:        []string{},
+			expectedFailureDomainKeyValue: "zone-1",
+			expecteNoOutSetting:           "",
 		},
-		Status: policyv1.PodDisruptionBudgetStatus{
-			DisruptionsAllowed: int32(0),
+		{
+			name:                          "case 2: Non-empty PDB config and no draining failureDomain",
+			pdbConfig:                     fakePDBConfigMap("zone-2"),
+			osdDownFailureDomains:         []string{"zone-1", "zone-2"},
+			drainingFailureDomains:        []string{},
+			expectedFailureDomainKeyValue: "zone-2",
+			expecteNoOutSetting:           "",
+		},
+		{
+			name:                          "case 3: Node drain event should set the no-out flag on the failure domain",
+			pdbConfig:                     fakePDBConfigMap(""),
+			osdDownFailureDomains:         []string{"zone-1", "zone-2"},
+			drainingFailureDomains:        []string{"zone-1"},
+			expectedFailureDomainKeyValue: "zone-1",
+			expecteNoOutSetting:           "true",
+		},
+		{
+			name:                          "case 3: failure domain with drained nodes should get higher precedence",
+			pdbConfig:                     fakePDBConfigMap(""),
+			osdDownFailureDomains:         []string{"zone-1", "zone-2", "zone-3"},
+			drainingFailureDomains:        []string{"zone-3"},
+			expectedFailureDomainKeyValue: "zone-3",
+			expecteNoOutSetting:           "true",
 		},
 	}
-	err = r.client.Create(context.TODO(), pdb)
-	assert.NoError(t, err)
-	allowedDisruptions, err = r.getAllowedDisruptions(osdPDBAppName, namespace)
-	assert.NoError(t, err)
-	assert.Equal(t, int32(0), allowedDisruptions)
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			setPDBConfig(tc.pdbConfig, tc.osdDownFailureDomains, tc.drainingFailureDomains)
+			assert.Equal(t, tc.expectedFailureDomainKeyValue, tc.pdbConfig.Data[drainingFailureDomainKey])
+			assert.Equal(t, tc.expecteNoOutSetting, tc.pdbConfig.Data[setNoOut])
+		})
+	}
+
 }

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -183,7 +183,6 @@ spec:
   disruptionManagement:
     managePodBudgets: true
     osdMaintenanceTimeout: 30
-    pgHealthCheckTimeout: 0
   healthCheck:
     daemonHealth:
       mon:


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

This backport PR allows one healthy OSD to go down during node drain event. 

Two commits are being cherry-picked here.  
https://github.com/rook/rook/pull/15408
https://github.com/rook/rook/pull/15634

More details about the fix can be found the respective PR descriptions. 



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
