### PR TITLE
DFBUGS-2929: object: retry rgw admin ops InvalidAccessKeyId workaround

### DIFF
--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/coreos/pkg/capnslog"
@@ -407,18 +408,38 @@ func (r *ReconcileObjectStoreUser) createOrUpdateCephUser(u *cephv1.CephObjectSt
 			}
 			logCreateOrUpdate = fmt.Sprintf("created ceph object user %q", u.Name)
 		} else if strings.Contains(err.Error(), "InvalidAccessKeyId") {
+			cooldown := 35 * time.Second
 			// In case of an Invalid Access Key, delete the `rgw-admin-ops-user` and restart the operator.
-			// This is a temporary fix until https://bugzilla.redhat.com/show_bug.cgi?id=2373031 is resolved.
+			// This is a temporary workaround until https://bugzilla.redhat.com/show_bug.cgi?id=2373031 is resolved.
 			logger.Errorf("failed to get Ceph Object user %q. Error: %v", u.Name, err)
-			logger.Infof("deleting the admin user %q", cephObject.RGWAdminOpsUserSecretName)
-			_, err := cephObject.DeleteUser(&r.objContext.Context, cephObject.RGWAdminOpsUserSecretName)
-			if err != nil {
-				return errors.Wrapf(err, "failed to delete admin user %q with InvalidAccessKeyID",
-					cephObject.RGWAdminOpsUserSecretName)
+			waSuccess := false
+			// user deletion can hang due to the same underlying reasons that create fails.
+			// in testing, radosgw-admin seemed to respond more often with ~30 second periodicity,
+			// so retry the deletion workaround with 35 second cooldown hoping for better chance of success.
+			for i := range 4 {
+				logger.Infof("waiting 35 seconds before attempting to delete admin user %q attempt %d", cephObject.RGWAdminOpsUserSecretName, i)
+				time.Sleep(cooldown)
+				logger.Infof("deleting the admin user %q attempt %d", cephObject.RGWAdminOpsUserSecretName, i)
+				_, err := cephObject.DeleteUser(&r.objContext.Context, cephObject.RGWAdminOpsUserSecretName)
+				if err != nil {
+					logger.Warningf("failed to delete admin user %q with InvalidAccessKeyID: %v",
+						cephObject.RGWAdminOpsUserSecretName, err)
+					waSuccess = false
+				} else {
+					waSuccess = true
+					break // workaround succeeded
+				}
 			}
-			logger.Warningf("restarting the operator to recreate the %q user", cephObject.RGWAdminOpsUserSecretName)
-			// restart the rook operator so that it will recreate the `rgw-admin-ops-user`
-			opcontroller.ReloadManager()
+			if waSuccess {
+				// wait 35 seconds before restarting operator in hopes that user creation will be more likely to succeed after a cooldown
+				logger.Infof("admin user %q deletion succeeded; waiting 35 seconds to retry user creation", cephObject.RGWAdminOpsUserSecretName)
+				time.Sleep(cooldown)
+				logger.Warningf("restarting the operator to recreate the %q user", cephObject.RGWAdminOpsUserSecretName)
+				// restart the rook operator so that it will recreate the `rgw-admin-ops-user`
+				opcontroller.ReloadManager()
+			} else {
+				logger.Warningf("failed to delete admin user %q with InvalidAccessKeyID after several attempts", cephObject.RGWAdminOpsUserSecretName)
+			}
 		} else {
 			return errors.Wrapf(err, "failed to get details from ceph object user %q", u.Name)
 		}


### PR DESCRIPTION
When Rook discovers that the RGW admin ops user is experiencing the InvalidAccessKeyId error, experimentation showed that the delete can fail. Logs suggested that radosgw-admin may be more likely to respond normally after ~30 second cooldowns.

In order to attempt to make the workaround more robust, retry the delete with a 35 second cooldown.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
