### PR TITLE
DFBUGS-3581: Rook workaround for RGW InvalidAccesskeyID error 

### DIFF
--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -207,7 +207,8 @@ func (c *CephToolCommand) run() ([]byte, error) {
 	// Still forcing the check for the command if the behavior changes in the future
 	if command == RBDTool || command == RadosTool || command == GaneshaRadosGraceTool {
 		if c.RemoteExecution {
-			output, stderr, err = c.context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(c.clusterInfo.Context, ProxyAppLabel, CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{command}, args...)...)
+			defaultTimeout := exec.CephCommandsTimeout
+			output, stderr, err = c.context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(c.clusterInfo.Context, ProxyAppLabel, CommandProxyInitContainerName, c.clusterInfo.Namespace, defaultTimeout, append([]string{command}, args...)...)
 			if err != nil {
 				err = errors.Errorf("%s", err.Error())
 			}

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httputil"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/coreos/pkg/capnslog"
@@ -225,15 +226,19 @@ func extractJSON(output string) (string, error) {
 // This function times out after a fixed interval if no response is received.
 // The function will return a Kubernetes error "NotFound" when exec fails when the pod does not exist
 func RunAdminCommandNoMultisite(c *Context, expectJSON bool, args ...string) (string, error) {
+	return RunAdminCommandNoMultisiteWithTimeout(c, expectJSON, exec.CephCommandsTimeout, args...)
+}
+
+func RunAdminCommandNoMultisiteWithTimeout(c *Context, expectJSON bool, timeout time.Duration, args ...string) (string, error) {
 	var output, stderr string
 	var err error
 
 	// If Multus is enabled we proxy all the command to the mgr sidecar
 	if c.clusterInfo.NetworkSpec.IsMultus() {
-		output, stderr, err = c.Context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(c.clusterInfo.Context, cephclient.ProxyAppLabel, cephclient.CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{"radosgw-admin"}, args...)...)
+		output, stderr, err = c.Context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(c.clusterInfo.Context, cephclient.ProxyAppLabel, cephclient.CommandProxyInitContainerName, c.clusterInfo.Namespace, timeout, append([]string{"radosgw-admin"}, args...)...)
 	} else {
 		command, args := cephclient.FinalizeCephCommandArgs("radosgw-admin", c.clusterInfo, args, c.Context.ConfigDir)
-		output, err = c.Context.Executor.ExecuteCommandWithTimeout(exec.CephCommandsTimeout, command, args...)
+		output, err = c.Context.Executor.ExecuteCommandWithTimeout(timeout, command, args...)
 	}
 
 	if err != nil {
@@ -252,6 +257,10 @@ func RunAdminCommandNoMultisite(c *Context, expectJSON bool, args ...string) (st
 
 // This function is for running radosgw-admin commands in scenarios where an object-store has been created and the Context has been updated with the appropriate realm, zone group, and zone.
 func runAdminCommand(c *Context, expectJSON bool, args ...string) (string, error) {
+	return runAdminCommandWithTimeout(c, expectJSON, exec.CephCommandsTimeout, args...)
+}
+
+func runAdminCommandWithTimeout(c *Context, expectJSON bool, timeout time.Duration, args ...string) (string, error) {
 	// If the objectStoreName is not passed in the storage class
 	// This means we are pointing to an external cluster so these commands are not needed
 	// simply because the external cluster mode does not support that yet
@@ -270,7 +279,7 @@ func runAdminCommand(c *Context, expectJSON bool, args ...string) (string, error
 
 	// work around FIFO file I/O issue when radosgw-admin is not compatible between version
 	// installed in Rook operator and RGW version in Ceph cluster (#7573)
-	result, err := RunAdminCommandNoMultisite(c, expectJSON, args...)
+	result, err := RunAdminCommandNoMultisiteWithTimeout(c, expectJSON, timeout, args...)
 	if err != nil && isFifoFileIOError(err) {
 		logger.Debugf("retrying 'radosgw-admin' command with OMAP backend to work around FIFO file I/O issue. %v", result)
 
@@ -278,10 +287,10 @@ func runAdminCommand(c *Context, expectJSON bool, args ...string) (string, error
 		// and then pick a flag to use, or we can just try to use both flags and return the one that
 		// works. Same number of commands being run.
 		retryArgs := append(args, "--rgw-data-log-backing=omap") // v16.2.0- in the operator
-		retryResult, retryErr := RunAdminCommandNoMultisite(c, expectJSON, retryArgs...)
+		retryResult, retryErr := RunAdminCommandNoMultisiteWithTimeout(c, expectJSON, timeout, retryArgs...)
 		if retryErr != nil && isInvalidFlagError(retryErr) {
 			retryArgs = append(args, "--rgw-default-data-log-backing=omap") // v16.2.1+ in the operator
-			retryResult, retryErr = RunAdminCommandNoMultisite(c, expectJSON, retryArgs...)
+			retryResult, retryErr = RunAdminCommandNoMultisiteWithTimeout(c, expectJSON, timeout, retryArgs...)
 		}
 
 		return retryResult, retryErr

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/pkg/errors"
@@ -116,6 +117,13 @@ func GetUser(c *Context, id string) (*ObjectUser, int, error) {
 // Subsequent interaction with the API will be done with the created user
 func CreateUser(c *Context, user ObjectUser, force bool) (*ObjectUser, int, error) {
 	logger.Debugf("creating s3 user %q", user.UserID)
+	timeout := exec.CephCommandsTimeout
+	if user.UserID == RGWAdminOpsUserSecretName {
+		// Setting a really long timeout for the command that creates the admin user
+		// This is a workaround until we find what is the root cause that the creation
+		// is commonly taking about two minutes, instead of sub-second as in previous releases.
+		timeout = 10 * time.Minute
+	}
 
 	if strings.TrimSpace(user.UserID) == "" {
 		return nil, RGWErrorBadData, errors.New("userId cannot be empty")
@@ -156,7 +164,7 @@ func CreateUser(c *Context, user ObjectUser, force bool) (*ObjectUser, int, erro
 		args = append(args, "--yes-i-really-mean-it")
 	}
 
-	result, err := runAdminCommand(c, true, args...)
+	result, err := runAdminCommandWithTimeout(c, true, timeout, args...)
 	if err != nil {
 		if code, err := exec.ExtractExitCode(err); err == nil && code == int(syscall.EEXIST) {
 			return nil, ErrorCodeFileExists, errors.New("s3 user already exists")

--- a/pkg/util/exec/exec_pod.go
+++ b/pkg/util/exec/exec_pod.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -130,6 +131,6 @@ func execute(ctx context.Context, method string, url *url.URL, config *rest.Conf
 	})
 }
 
-func (e *RemotePodCommandExecutor) ExecCommandInContainerWithFullOutputWithTimeout(ctx context.Context, appLabel, containerName, namespace string, cmd ...string) (string, string, error) {
-	return e.ExecCommandInContainerWithFullOutput(ctx, appLabel, containerName, namespace, append([]string{"timeout", strconv.Itoa(int(CephCommandsTimeout.Seconds()))}, cmd...)...)
+func (e *RemotePodCommandExecutor) ExecCommandInContainerWithFullOutputWithTimeout(ctx context.Context, appLabel, containerName, namespace string, timeout time.Duration, cmd ...string) (string, string, error) {
+	return e.ExecCommandInContainerWithFullOutput(ctx, appLabel, containerName, namespace, append([]string{"timeout", strconv.Itoa(int(timeout.Seconds()))}, cmd...)...)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

This PR is cherry pick from three other PRs that were merged in 4.19 as a workaround for the InvalidAccessKeyID error.  Description of changes: 
- If InvalidAccessKeyID is hit, then delete the rgw-admin-ops user (with a timeout and retry) and restart the operator so that it will recreate the `rgw-admin-ops-user` 
- Increase the timeout of `create` request sent to ceph to create the `rgw-admin-ops-user`. The timeout is increased from 15 seconds to 10 minutes. 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
