### PR TITLE
rbdmirror: fix status check for rbd rn mirroring

### DIFF
--- a/pkg/operator/ceph/pool/radosnamespace/controller.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller.go
@@ -592,7 +592,7 @@ func (r *ReconcileCephBlockPoolRadosNamespace) reconcileMirroring(cephBlockPoolR
 		}
 	}
 
-	if cephBlockPool.Spec.StatusCheck.Mirror.Disabled {
+	if cephBlockPool.Spec.StatusCheck.Mirror.Disabled || (!cephBlockPool.Spec.Mirroring.Enabled && cephBlockPoolRadosNamespace.Spec.Mirroring == nil) {
 		// Stop monitoring the mirroring status of this radosNamespace
 		if radosNamespaceContextsExists && r.radosNamespaceContexts[radosNamespaceChannelKey].started {
 			r.cancelMirrorMonitoring(radosNamespaceChannelKey)


### PR DESCRIPTION
if the blockpool mirroring is disabled and status check is not removed, currently rn cr still watches for the status

Add a check if the pool or rados mirroring is disabled then dont watch for status


(cherry picked from commit 11b3d7e16eb22442d87f5b795542b0031d276850)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
