### PR TITLE
DFBUGS-4101: mon: fix mon health nil pointer exception

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -394,6 +394,11 @@ func (c *Cluster) shouldFailoverMonImmediately(ctx context.Context, monName stri
 	logger.Debugf("checking if mon %q is scheduled on a node", monName)
 	assignedNode := ""
 	if mapping, ok := c.mapping.Schedule[monName]; ok {
+		if mapping == nil {
+			// mon schedule information is not available in the rook-ceph-mon-endpoints configmap in case of mons on PVC
+			logger.Debugf("mon schedule information is not available for mon %q", monName)
+			return false
+		}
 		assignedNode = mapping.Hostname
 	}
 	if assignedNode == "" {


### PR DESCRIPTION
shouldFailoverMonImmediately has a nil pointer exception with mons on PVC. Rook-ceph-mon-endpoint does not store node information of the mons on PVC. So `mapping.Hostname` throws nill pointer


(cherry picked from commit d399615bdc6fadcd191feff3a5ec10fb9c31ecca)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
