### PR TITLE
DFBUGS-4108: core: use updated context in prevalidaiton checks

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -247,6 +247,7 @@ func (c *ClusterController) initializeCluster(cluster *cluster) error {
 }
 
 func (c *ClusterController) configureLocalCephCluster(cluster *cluster) error {
+	cluster.ClusterInfo.Context = c.OpManagerCtx
 	// Cluster Spec validation
 	err := preClusterStartValidation(cluster)
 	if err != nil {
@@ -270,8 +271,6 @@ func (c *ClusterController) configureLocalCephCluster(cluster *cluster) error {
 	}
 
 	controller.UpdateCondition(c.OpManagerCtx, c.context, c.namespacedName, k8sutil.ObservedGenerationNotAvailable, cephv1.ConditionProgressing, v1.ConditionTrue, cephv1.ClusterProgressingReason, "Configuring the Ceph cluster")
-
-	cluster.ClusterInfo.Context = c.OpManagerCtx
 	// Run the orchestration
 	err = cluster.reconcileCephDaemons(c.rookImage, *cephVersion)
 	if err != nil {


### PR DESCRIPTION
If the CephCluster spec is updated before the prevalidation check, then Cluster.context still refers to the cancelled context of the operator. This PR just updates the cluster context to use the latest operator context.


(cherry picked from commit 1ff7604f820481ddb1ca30edd14eada652c2f81b)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
