### PR TITLE
DFBUGS-4060: external: fix ipv6 monitoring endpoint reconcile

### DIFF
--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"net"
 	"os"
 	"path"
 	"reflect"
@@ -954,7 +955,12 @@ func ConfigureExternalMetricsEndpoint(ctx *clusterd.Context, monitoringSpec ceph
 }
 
 func extractMgrIP(rawActiveAddr string) string {
-	return strings.Split(rawActiveAddr, ":")[0]
+	host, _, err := net.SplitHostPort(rawActiveAddr)
+	if err != nil {
+		// If there's no port, return as is
+		return rawActiveAddr
+	}
+	return host
 }
 
 func GetContainerImagePullPolicy(containerImagePullPolicy v1.PullPolicy) v1.PullPolicy {

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -259,6 +259,22 @@ func TestExtractMgrIP(t *testing.T) {
 	activeMgrRaw := "172.17.0.12:6801/2535462469"
 	ip := extractMgrIP(activeMgrRaw)
 	assert.Equal(t, "172.17.0.12", ip)
+
+	activeMgrRaw = "[2001:db8::1]:6801/2535462469"
+	ip = extractMgrIP(activeMgrRaw)
+	assert.Equal(t, "2001:db8::1", ip)
+
+	activeMgrRaw = "invalid-address"
+	ip = extractMgrIP(activeMgrRaw)
+	assert.Equal(t, activeMgrRaw, ip)
+
+	activeMgrRaw = ""
+	ip = extractMgrIP(activeMgrRaw)
+	assert.Equal(t, "", ip)
+
+	activeMgrRaw = "172.17.0.12"
+	ip = extractMgrIP(activeMgrRaw)
+	assert.Equal(t, activeMgrRaw, ip)
 }
 
 func TestConfigureExternalMetricsEndpoint(t *testing.T) {


### PR DESCRIPTION
currently the extraction ipv6 was not correct
used the net package to extract the host ip from
the ipadress


(cherry picked from commit e1873cb2e74feb36b65db45fac2c189c02456b98)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
