### PR TITLE
DFBUGS-2775: rbdmirror: fix mirroring monitoring settings for rn

### DIFF
--- a/pkg/daemon/ceph/client/mirror_health.go
+++ b/pkg/daemon/ceph/client/mirror_health.go
@@ -180,7 +180,10 @@ func updateRadosNamespaceStatusMirroring(c *mirrorChecker, mirrorStatus *cephv1.
 
 	if blockPool.Spec.StatusCheck.Mirror.Disabled {
 		logger.Debugf("mirroring status check is disabled for %q", c.namespacedName.Name)
-		return
+		mirrorStatus = nil
+		mirrorInfo = nil
+		snapSchedStatus = nil
+		details = ""
 	}
 
 	// Update the CephBlockPoolRadosNamespace CR status field
@@ -222,7 +225,7 @@ func toCustomResourceStatus(currentStatus *cephv1.MirroringStatusSpec, mirroring
 	mirroringInfoSpec.Details = details
 
 	if currentInfo != nil {
-		mirroringInfoSpec.LastChanged = currentInfo.LastChecked
+		mirroringInfoSpec.LastChanged = currentInfo.LastChanged
 	}
 
 	// snapSchedStatus will be nil in case of an error to fetch it
@@ -234,7 +237,7 @@ func toCustomResourceStatus(currentStatus *cephv1.MirroringStatusSpec, mirroring
 	snapshotScheduleStatusSpec.Details = details
 
 	if currentSnapSchedStatus != nil {
-		snapshotScheduleStatusSpec.LastChanged = currentSnapSchedStatus.LastChecked
+		snapshotScheduleStatusSpec.LastChanged = currentSnapSchedStatus.LastChanged
 	}
 
 	return mirroringStatusSpec, mirroringInfoSpec, snapshotScheduleStatusSpec

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -394,9 +394,9 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 			if blockPoolContextsExists && r.blockPoolContexts[blockPoolChannelKey].started {
 				logger.Info("stop monitoring the mirroring status of the pool %q", cephBlockPool.Name)
 				r.cancelMirrorMonitoring(cephBlockPool)
-				// Reset the MirrorHealthCheckSpec
-				checker.UpdateStatusMirroring(nil, nil, nil, "")
 			}
+			// Reset the MirrorHealthCheckSpec
+			checker.UpdateStatusMirroring(nil, nil, nil, "")
 		} else {
 			// Start monitoring of the pool
 			if r.blockPoolContexts[blockPoolChannelKey].started {
@@ -425,9 +425,9 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 		// Stop monitoring the mirroring status of this pool
 		if blockPoolContextsExists && r.blockPoolContexts[blockPoolChannelKey].started {
 			r.cancelMirrorMonitoring(cephBlockPool)
-			// Reset the MirrorHealthCheckSpec
-			checker.UpdateStatusMirroring(nil, nil, nil, "")
 		}
+		// Reset the MirrorHealthCheckSpec
+		checker.UpdateStatusMirroring(nil, nil, nil, "")
 	}
 
 	if statusErr != nil {

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -562,7 +562,7 @@ func TestCephBlockPoolController(t *testing.T) {
 		err = r.client.Get(context.TODO(), req.NamespacedName, pool)
 		assert.NoError(t, err)
 		assert.Equal(t, cephv1.ConditionReady, pool.Status.Phase)
-		assert.Nil(t, pool.Status.MirroringStatus)
+		assert.Equal(t, pool.Status.MirroringStatus, &cephv1.MirroringStatusSpec{})
 	})
 }
 

--- a/pkg/operator/ceph/pool/radosnamespace/controller.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller.go
@@ -596,9 +596,9 @@ func (r *ReconcileCephBlockPoolRadosNamespace) reconcileMirroring(cephBlockPoolR
 		// Stop monitoring the mirroring status of this radosNamespace
 		if radosNamespaceContextsExists && r.radosNamespaceContexts[radosNamespaceChannelKey].started {
 			r.cancelMirrorMonitoring(radosNamespaceChannelKey)
-			// Reset the MirrorHealthCheckSpec
-			checker.UpdateStatusMirroring(nil, nil, nil, "")
 		}
+		// Reset the MirrorHealthCheckSpec
+		checker.UpdateStatusMirroring(nil, nil, nil, "")
 	}
 
 	return nil


### PR DESCRIPTION
currently if we disable the monitoring for rn,
it doesnt reset the status


(cherry picked from commit 49c26dbfb0b486086dcf05a784430a6d61fc05fa)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
