### PR TITLE
csi: taint and untaint node during node fencing

### DIFF
--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -466,13 +466,22 @@ spec:
                 - ""
               resources:
                 - pods
-                - nodes
                 - secrets
                 - configmaps
               verbs:
                 - get
                 - list
                 - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+                - patch
+                - update
             - apiGroups:
                 - ""
                 - discovery.k8s.io

--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -80,8 +80,6 @@ rules:
     resources:
       # Pod access is needed for fencing
       - pods
-      # Node access is needed for determining nodes where mons should run
-      - nodes
       # Rook watches secrets which it uses to configure access to external resources.
       # e.g., external Ceph cluster or object store
       - secrets
@@ -91,6 +89,18 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      # Node access is needed for determining nodes where mons should run
+      # plus needed during the fencing event to add node annotations and add node taints.
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
   - apiGroups:
       - ""
       - "discovery.k8s.io"

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -310,8 +310,6 @@ rules:
     resources:
       # Pod access is needed for fencing
       - pods
-      # Node access is needed for determining nodes where mons should run
-      - nodes
       # Rook watches secrets which it uses to configure access to external resources.
       # e.g., external Ceph cluster or object store
       - secrets
@@ -321,6 +319,18 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      # Node access is needed for determining nodes where mons should run
+      # plus needed during the fencing event to add node annotations and add node taints.
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
   - apiGroups:
       - ""
       - "discovery.k8s.io"

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -484,6 +484,8 @@ func (c *ClusterController) reconcileCephCluster(clusterObj *cephv1.CephCluster,
 	c.clusterMap.Store(clustr.Namespace, clustr)
 	log.NamedInfo(clustr.namespacedName, logger, "reconciling ceph cluster")
 
+	c.startGoRoutineForFloatingMon(c.OpManagerCtx, clustr, clusterObj)
+
 	// Start the main ceph cluster orchestration
 	return c.initializeCluster(clustr)
 }
@@ -517,6 +519,8 @@ func (c *ClusterController) requestClusterDelete(clusterObj *cephv1.CephCluster)
 				existingCluster.monitoringRoutines.Delete(daemon)
 			}
 		}
+
+		cancelFloatingMonGoRoutine(existingCluster)
 	}
 
 	if clusterObj.Spec.CleanupPolicy.AllowUninstallWithVolumes {

--- a/pkg/operator/ceph/cluster/node_fencing.go
+++ b/pkg/operator/ceph/cluster/node_fencing.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cluster to manage a Ceph cluster.
+package cluster
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/util/log"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	pacemakerFencingEventName                  = "PacemakerFencingEvent"
+	pacemakerFencingEventNamespace             = "openshift-etcd"
+	pacemakerFencingEventTimeNodeAnnotationKey = "ceph.rook.io/pacemaker-fencing-event-time"
+	operatorAddTaintAnnotationKey              = "ceph.rook.io/pacemaker-fencing-taint"
+	pacemakerEventTriggerObjectKind            = "CronJob"
+	pacemakerEventTriggerObjectName            = "pacemaker-status-collector"
+	outOfServiceTaint                          = "node.kubernetes.io/out-of-service"
+)
+
+func (c *ClusterController) startGoRoutineForFloatingMon(ctx context.Context, clustr *cluster, clusterObj *cephv1.CephCluster) {
+	if clusterObj.Spec.Mon.FloatingMon.Name == "" {
+		return
+	}
+
+	// Check if we already have a routine running for this
+	if _, running := clustr.monitoringRoutines.Load("node-fencing"); !running {
+		log.NamespacedInfo(clustr.Namespace, logger, "starting dedicated node-fencing flow")
+
+		// Create a context linked to the controller's lifecycle
+		fencingCtx, fencingCancel := context.WithCancel(c.OpManagerCtx)
+
+		// Store it so we don't spawn it again
+		clustr.monitoringRoutines.Store("node-fencing", &opcontroller.ClusterHealth{
+			InternalCtx:    fencingCtx,
+			InternalCancel: fencingCancel,
+		})
+
+		// Start the separate flow
+		go c.startNodeFencingFlow(fencingCtx, clusterObj, clustr)
+	} else {
+		log.NamespacedDebug(clustr.Namespace, logger, "go routine for node-fencing flow is already running, skipping start of a new one")
+	}
+}
+
+func cancelFloatingMonGoRoutine(clustr *cluster) {
+	fence, ok := clustr.monitoringRoutines.Load("node-fencing")
+	if ok && fence.(*opcontroller.ClusterHealth).InternalCtx.Err() == nil {
+		// Stop the node-fencing routine
+		fence.(*opcontroller.ClusterHealth).InternalCancel()
+
+		// Remove the node-fencing routine from the map
+		clustr.monitoringRoutines.Delete("node-fencing")
+	}
+}
+
+func (c *ClusterController) startNodeFencingFlow(ctx context.Context, cluster *cephv1.CephCluster, clustr *cluster) {
+	// Define the 5-minute interval
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	// Run the node fencing flow immediately when the controller starts, to make sure the node status is updated in a
+	// Stimely manner when the controller starts, and then run the node fencing flow every 5 minutes to make sure the
+	// node status is updated in a timely manner
+	runNodeFecingFlow(ctx, c.client, cluster)
+
+	for {
+		select {
+		case <-ticker.C:
+			// list nodes
+			runNodeFecingFlow(ctx, c.client, cluster)
+		case <-ctx.Done():
+			// This triggers if the controller restarts or OpManagerCtx is cancelled
+			log.NamespacedInfo(cluster.Namespace, logger, "terminating node-fencing flow")
+			// cleanup sync map
+			clustr.monitoringRoutines.Delete("node-fencing")
+			return
+		}
+	}
+}
+
+func runNodeFecingFlow(ctx context.Context, c client.Client, cluster *cephv1.CephCluster) {
+	// list nodes
+	nodes := &corev1.NodeList{}
+	err := c.List(ctx, nodes)
+	if err != nil {
+		log.NamespacedError(cluster.Namespace, logger, "failed to list nodes for pacemaker fencing events: %v", err)
+		return
+	}
+	for _, node := range nodes.Items {
+		log.NamespacedDebug(cluster.Namespace, logger, "checking node %q for pacemaker fencing events", node.Name)
+		reconcileNodeFencing(ctx, c, &node)
+	}
+}
+
+func reconcileNodeFencing(ctx context.Context, client client.Client, objNew *corev1.Node) {
+	newReady := getNodeReadyStatus(objNew)
+
+	// 	check the current node status:
+	// 1. If the node status is ready:
+	// 	  a. If the operator annotation is there, Remove the annotation
+	//    b.If not there return silently
+	// 2. If the node status is not ready:
+	//    a. if the operator annotation was there return silently
+	//    b. Add operator annotation, taint the node
+	if isNodeDown(newReady) {
+		log.NamespacedInfo("", logger, "node %s status is %s", objNew.Name, newReady)
+		handleNodeDown(ctx, client, objNew)
+		return
+	}
+	if isNodeUp(newReady) {
+		log.NamespacedDebug("", logger, "node %s status is %s", objNew.Name, newReady)
+		handleNodeUp(ctx, client, objNew)
+		return
+	}
+
+	log.NamespacedDebug("", logger, "node %s status is unknown %s, skipping", objNew.Name, newReady)
+}
+
+func getNodeReadyStatus(node *corev1.Node) corev1.ConditionStatus {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status
+		}
+	}
+	return corev1.ConditionUnknown
+}
+
+func isNodeDown(status corev1.ConditionStatus) bool {
+	return (status == corev1.ConditionFalse || status == corev1.ConditionUnknown)
+}
+
+func isNodeUp(status corev1.ConditionStatus) bool {
+	return status == corev1.ConditionTrue
+}
+
+// check for the pacemaker event `PacemakerFencingEvent` in `openshift-etcd` namespace
+// add annotation to the node with the new pacemaker event time
+// add an annotation at the node to know the taint will be added the operator
+// add the node taints `node.kubernetes.io/out-of-service=nodeshutdown:NoExecute` `node.kubernetes.io/out-of-service=nodeshutdown:NoSchedule`
+func handleNodeDown(ctx context.Context, c client.Client, node *corev1.Node) bool {
+	log.NamespacedDebug("", logger, "node %s is in DOWN state, checking for pacemaker fencing event", node.Name)
+	// get the pacemaker event `PacemakerFencingEvent` in `openshift-etcd` namespace
+	paceMakerEvents, exist := getPaceMakerEvents(ctx, c)
+	if !exist {
+		log.NamespacedDebug("", logger, "no pacemaker fencing event found for node %s, skipping adding taints", node.Name)
+		return false
+	}
+
+	// find the latest pacemaker event from the event list, by comparing the fencing event time
+	hostnameLabel := node.Labels["kubernetes.io/hostname"]
+	latestEventFencingTime, err := getLatestPaceMakerEvent(paceMakerEvents, node.Name, hostnameLabel)
+	if err != nil {
+		log.NamespacedWarning("", logger, "failed to get the latest pacemaker fencing event for node %s: %v", node.Name, err)
+		return false
+	}
+	if latestEventFencingTime.IsZero() {
+		log.NamespacedDebug("", logger, "no new pacemaker fencing event found for node %s, skipping adding taints", node.Name)
+		return false
+	}
+
+	// get node annotation `ceph.rook.io/pacemaker-fencing-event-time` and compare with the fencing event time,
+	// if the annotation time is before the fencing event time, it means the node is not updated with the latest fencing event,
+	// we will update the node with the latest fencing event time and add taints,
+	// if the annotation time is equal or after the fencing event time, it means the node is already updated with the latest fencing event,
+	// we will not update the node and taints again
+
+	if node.Annotations[pacemakerFencingEventTimeNodeAnnotationKey] == "" {
+		node.Annotations[pacemakerFencingEventTimeNodeAnnotationKey] = latestEventFencingTime.Time.Format(time.RFC3339Nano)
+	} else {
+		annotationTime := node.Annotations[pacemakerFencingEventTimeNodeAnnotationKey]
+		annotationParseTime, err := getParseTime(annotationTime)
+		if err != nil {
+			log.NamespacedWarning("", logger, "failed to parse pacemaker fencing event time from node annotation for node %s: %v", node.Name, err)
+			return false
+		}
+
+		if annotationParseTime.After(latestEventFencingTime.Time) || annotationParseTime.Equal(latestEventFencingTime.Time) {
+			log.NamespacedDebug("", logger, "node %s is already updated with the latest pacemaker fencing event, no need to update the node and taints again", node.Name)
+			return false
+		}
+
+		node.Annotations[pacemakerFencingEventTimeNodeAnnotationKey] = latestEventFencingTime.Time.Format(time.RFC3339Nano)
+	}
+
+	// add an annotation at the node to know the taint will be added the operator
+	node.Annotations[operatorAddTaintAnnotationKey] = "true"
+
+	// add the node taints `node.kubernetes.io/out-of-service=nodeshutdown:NoExecute` `node.kubernetes.io/out-of-service=nodeshutdown:NoSchedule`
+	taintNoExecute := corev1.Taint{
+		Key:    outOfServiceTaint,
+		Value:  "nodeshutdown",
+		Effect: corev1.TaintEffectNoExecute,
+	}
+	taintNoSchedule := corev1.Taint{
+		Key:    outOfServiceTaint,
+		Value:  "nodeshutdown",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+
+	// add taint if not exist
+	taintNoExecuteExists, taintNoScheduleExists := false, false
+	for _, t := range node.Spec.Taints {
+		if t.MatchTaint(&taintNoExecute) {
+			taintNoExecuteExists = true
+		}
+		if t.MatchTaint(&taintNoSchedule) {
+			taintNoScheduleExists = true
+		}
+	}
+	if !taintNoExecuteExists {
+		node.Spec.Taints = append(node.Spec.Taints, taintNoExecute)
+	}
+	if !taintNoScheduleExists {
+		node.Spec.Taints = append(node.Spec.Taints, taintNoSchedule)
+	}
+
+	// update the node with the latest fencing event time annotation and taints
+	err = c.Update(ctx, node)
+	if err != nil {
+		log.NamespacedError("", logger, "failed to update node %s with the latest pacemaker fencing event time annotation and taints: %v", node.Name, err)
+		return false
+	}
+
+	log.NamespacedInfo("", logger, "node %s is updated with the latest pacemaker fencing event time annotation and taints", node.Name)
+
+	return true
+}
+
+func getParseTime(timestring string) (time.Time, error) {
+	parsedTime, err := time.Parse(time.RFC3339Nano, timestring)
+	if err != nil {
+		log.NamespacedWarning("", logger, "failed to parse pacemaker fencing event time: %v", err)
+		return time.Time{}, err
+	}
+	return parsedTime, nil
+}
+
+func getPaceMakerEvents(ctx context.Context, c client.Client) ([]*corev1.Event, bool) {
+	events := &corev1.EventList{}
+	// todo: do event field indexing for matching fields, and use field selector to get the event instead of list and loop
+	err := c.List(ctx, events, client.InNamespace(pacemakerFencingEventNamespace))
+	if err != nil {
+		log.NamespacedError("", logger, "failed to list events in namespace openshift-etcd: %v", err)
+		return nil, false
+	}
+	eventList := make([]*corev1.Event, 0)
+
+	for _, e := range events.Items {
+		if e.InvolvedObject.Kind == pacemakerEventTriggerObjectKind && e.InvolvedObject.Name == pacemakerEventTriggerObjectName && e.Reason == pacemakerFencingEventName {
+			eventList = append(eventList, e.DeepCopy())
+		}
+	}
+
+	if len(eventList) == 0 {
+		log.NamespacedDebug("", logger, "no pacemaker fencing event found in namespace openshift-etcd")
+		return nil, false
+	}
+	return eventList, true
+}
+
+func getLatestPaceMakerEvent(events []*corev1.Event, nodeName, hostnameLabel string) (v1.Time, error) {
+	var latestEvent *corev1.Event
+
+	for _, e := range events {
+		// get the node name from the fencing event message,
+		// the message format is: `Fencing event: reboot of master-1 completed with status success at 2026-01-29 18:08:34.437689Z`
+
+		node, err := getNodeNameFromEventMessage(e.Message)
+		if err != nil {
+			log.NamespacedWarning("", logger, "failed to get node name from pacemaker fencing event message: %v", err)
+			continue
+		}
+		if node == nodeName || node == hostnameLabel {
+			// use FirstTimestamp to compare the event time, because the event will be updated with the latest timestamp when the event is updated,
+			// but the FirstTimestamp will not be updated, it will keep the original event time when the event is created, so we can use FirstTimestamp
+			// to compare the event time
+			// ps: we can also use the event fencing time in the event message, but it will require more parsing and error handling,
+			// so we choose to use the FirstTimestamp for simplicity
+			if latestEvent == nil || (e.FirstTimestamp.After(latestEvent.FirstTimestamp.Time)) {
+				latestEvent = e
+			}
+		}
+	}
+
+	if latestEvent == nil {
+		log.NamespacedDebug("", logger, "no pacemaker fencing event found for node %s", nodeName)
+		return v1.Time{}, nil
+	}
+
+	return latestEvent.FirstTimestamp, nil
+}
+
+func getNodeNameFromEventMessage(message string) (string, error) {
+	// Regular expression to extract node name from pacemaker fencing event message
+	// Expected format: "Fencing event: reboot of <node-name> completed with status ..."
+	pacemakerEventMessageRegex := regexp.MustCompile(`^Fencing event: reboot of (\S+) completed`)
+	matches := pacemakerEventMessageRegex.FindStringSubmatch(message)
+	if len(matches) < 2 {
+		return "", errors.Errorf("failed to parse node name from pacemaker fencing event message: %s", message)
+	}
+	return matches[1], nil
+}
+
+// remove the taints
+// remove the annotation that the taint was added by the user
+func handleNodeUp(ctx context.Context, c client.Client, node *corev1.Node) bool {
+	log.NamespacedDebug("", logger, "node %s is in UP state, removing taints and annotations", node.Name)
+
+	// check if the annotation `ceph.rook.io/pacemaker-fencing-taint` exists, if not exist, it means the taints are not added by the operator, we will not remove the taints and annotation
+	if node.Annotations[operatorAddTaintAnnotationKey] == "" {
+		log.NamespacedDebug("", logger, "annotation %s is not found on node %s, it means the taints are not added by the operator, skipping removing taints and annotation", operatorAddTaintAnnotationKey, node.Name)
+		return false
+	}
+
+	// remove the node taints `node.kubernetes.io/out-of-service=nodeshutdown:NoExecute` `node.kubernetes.io/out-of-service=nodeshutdown:NoSchedule`
+	var newTaints []corev1.Taint
+	for _, t := range node.Spec.Taints {
+		if t.Key == outOfServiceTaint && t.Value == "nodeshutdown" && (t.Effect == corev1.TaintEffectNoExecute || t.Effect == corev1.TaintEffectNoSchedule) {
+			continue
+		}
+		newTaints = append(newTaints, t)
+	}
+	node.Spec.Taints = newTaints
+
+	// remove the annotation `ceph.rook.io/pacemaker-fencing-taint`
+	delete(node.Annotations, operatorAddTaintAnnotationKey)
+
+	// update the node
+	err := c.Update(ctx, node)
+	if err != nil {
+		log.NamespacedError("", logger, "failed to update node %s with the latest pacemaker fencing event time annotation and taints: %v", node.Name, err)
+		return false
+	}
+
+	log.NamespacedInfo("", logger, "node %s is updated by removing the pacemaker fencing event time annotation and taints", node.Name)
+	return false
+}

--- a/pkg/operator/ceph/cluster/node_fencing_test.go
+++ b/pkg/operator/ceph/cluster/node_fencing_test.go
@@ -1,0 +1,810 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cluster to manage a Ceph cluster.
+package cluster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetNodeReadyStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *corev1.Node
+		expected corev1.ConditionStatus
+	}{
+		{
+			name: "node with ready status true",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			expected: corev1.ConditionTrue,
+		},
+		{
+			name: "node with ready status false",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			expected: corev1.ConditionFalse,
+		},
+		{
+			name: "node with ready status unknown",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionUnknown},
+					},
+				},
+			},
+			expected: corev1.ConditionUnknown,
+		},
+		{
+			name: "node with no ready condition",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			expected: corev1.ConditionUnknown,
+		},
+		{
+			name: "node with multiple conditions",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			expected: corev1.ConditionTrue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getNodeReadyStatus(tt.node)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsNodeDown(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   corev1.ConditionStatus
+		expected bool
+	}{
+		{
+			name:     "status false should return true",
+			status:   corev1.ConditionFalse,
+			expected: true,
+		},
+		{
+			name:     "status unknown should return true",
+			status:   corev1.ConditionUnknown,
+			expected: true,
+		},
+		{
+			name:     "status true should return false",
+			status:   corev1.ConditionTrue,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isNodeDown(tt.status)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsNodeUp(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   corev1.ConditionStatus
+		expected bool
+	}{
+		{
+			name:     "status true should return true",
+			status:   corev1.ConditionTrue,
+			expected: true,
+		},
+		{
+			name:     "status false should return false",
+			status:   corev1.ConditionFalse,
+			expected: false,
+		},
+		{
+			name:     "status unknown should return false",
+			status:   corev1.ConditionUnknown,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isNodeUp(tt.status)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetParseTime(t *testing.T) {
+	tests := []struct {
+		name        string
+		timeString  string
+		expectError bool
+	}{
+		{
+			name:        "valid RFC3339Nano time",
+			timeString:  "2026-01-29T18:08:34.437689Z",
+			expectError: false,
+		},
+		{
+			name:        "valid RFC3339 time without nano",
+			timeString:  "2026-01-29T18:08:34Z",
+			expectError: false,
+		},
+		{
+			name:        "invalid time format",
+			timeString:  "invalid-time",
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			timeString:  "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := getParseTime(tt.timeString)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.True(t, result.IsZero())
+			} else {
+				assert.NoError(t, err)
+				assert.False(t, result.IsZero())
+			}
+		})
+	}
+}
+
+func TestGetNodeNameFromEventMessage(t *testing.T) {
+	tests := []struct {
+		name         string
+		message      string
+		expectedNode string
+		expectError  bool
+	}{
+		{
+			name:         "valid pacemaker event message",
+			message:      "Fencing event: reboot of master-1 completed with status success at 2026-01-29 18:08:34.437689Z",
+			expectedNode: "master-1",
+			expectError:  false,
+		},
+		{
+			name:         "valid message with different node name",
+			message:      "Fencing event: reboot of worker-node-2 completed with status success at 2026-01-29 18:08:34.437689Z",
+			expectedNode: "worker-node-2",
+			expectError:  false,
+		},
+		{
+			name:        "invalid message format",
+			message:     "some random message",
+			expectError: true,
+		},
+		{
+			name:        "partial message",
+			message:     "Fencing event: reboot of",
+			expectError: true,
+		},
+		{
+			name:        "empty message",
+			message:     "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := getNodeNameFromEventMessage(tt.message)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedNode, result)
+			}
+		})
+	}
+}
+
+func TestGetPaceMakerEvents(t *testing.T) {
+	ctx := context.TODO()
+
+	tests := []struct {
+		name           string
+		events         []runtime.Object
+		expectedCount  int
+		expectedExists bool
+	}{
+		{
+			name: "valid pacemaker events exist",
+			events: []runtime.Object{
+				&corev1.Event{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "pacemaker-event-1",
+						Namespace: pacemakerFencingEventNamespace,
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: pacemakerEventTriggerObjectKind,
+						Name: pacemakerEventTriggerObjectName,
+					},
+					Reason:  pacemakerFencingEventName,
+					Message: "Fencing event: reboot of master-1 completed with status success at 2026-01-29 18:08:34.437689Z",
+				},
+			},
+			expectedCount:  1,
+			expectedExists: true,
+		},
+		{
+			name: "no matching events",
+			events: []runtime.Object{
+				&corev1.Event{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "other-event",
+						Namespace: pacemakerFencingEventNamespace,
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: "Pod",
+						Name: "some-pod",
+					},
+					Reason: "SomeOtherReason",
+				},
+			},
+			expectedCount:  0,
+			expectedExists: false,
+		},
+		{
+			name: "events in wrong namespace",
+			events: []runtime.Object{
+				&corev1.Event{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "pacemaker-event",
+						Namespace: "wrong-namespace",
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: pacemakerEventTriggerObjectKind,
+						Name: pacemakerEventTriggerObjectName,
+					},
+					Reason: pacemakerFencingEventName,
+				},
+			},
+			expectedCount:  0,
+			expectedExists: false,
+		},
+		{
+			name: "multiple valid pacemaker events",
+			events: []runtime.Object{
+				&corev1.Event{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "event-1",
+						Namespace: pacemakerFencingEventNamespace,
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: pacemakerEventTriggerObjectKind,
+						Name: pacemakerEventTriggerObjectName,
+					},
+					Reason:  pacemakerFencingEventName,
+					Message: "Fencing event: reboot of master-1 completed with status success",
+				},
+				&corev1.Event{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "event-2",
+						Namespace: pacemakerFencingEventNamespace,
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: pacemakerEventTriggerObjectKind,
+						Name: pacemakerEventTriggerObjectName,
+					},
+					Reason:  pacemakerFencingEventName,
+					Message: "Fencing event: reboot of master-2 completed with status success",
+				},
+			},
+			expectedCount:  2,
+			expectedExists: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tt.events...).Build()
+
+			events, exists := getPaceMakerEvents(ctx, client)
+			assert.Equal(t, tt.expectedExists, exists)
+			assert.Equal(t, tt.expectedCount, len(events))
+		})
+	}
+}
+
+func TestGetLatestPaceMakerEvent(t *testing.T) {
+	now := time.Now()
+	earlier := now.Add(-1 * time.Hour)
+	latest := now
+
+	tests := []struct {
+		name          string
+		events        []*corev1.Event
+		nodeName      string
+		hostnameLabel string
+		expectError   bool
+	}{
+		{
+			name: "single event for node",
+			events: []*corev1.Event{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "event-1",
+					},
+					Message:        "Fencing event: reboot of master-1 completed with status success",
+					FirstTimestamp: v1.Time{Time: now},
+				},
+			},
+			nodeName:      "master-1",
+			hostnameLabel: "master-1",
+			expectError:   false,
+		},
+		{
+			name: "multiple events for node, return latest",
+			events: []*corev1.Event{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "event-1",
+					},
+					Message:        "Fencing event: reboot of master-1 completed with status success",
+					FirstTimestamp: v1.Time{Time: earlier},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "event-2",
+					},
+					Message:        "Fencing event: reboot of master-1 completed with status success",
+					FirstTimestamp: v1.Time{Time: latest},
+				},
+			},
+			nodeName:      "master-1",
+			hostnameLabel: "master-1",
+			expectError:   false,
+		},
+		{
+			name: "no events for target node",
+			events: []*corev1.Event{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "event-1",
+					},
+					Message:        "Fencing event: reboot of master-1 completed with status success",
+					FirstTimestamp: v1.Time{Time: now},
+				},
+			},
+			nodeName:      "master-2",
+			hostnameLabel: "master-2",
+			expectError:   false,
+		},
+		{
+			name: "events for different nodes",
+			events: []*corev1.Event{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "event-1",
+					},
+					Message:        "Fencing event: reboot of master-1 completed with status success",
+					FirstTimestamp: v1.Time{Time: earlier},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "event-2",
+					},
+					Message:        "Fencing event: reboot of master-2 completed with status success",
+					FirstTimestamp: v1.Time{Time: latest},
+				},
+			},
+			nodeName:      "master-2",
+			hostnameLabel: "master-2",
+			expectError:   false,
+		},
+		{
+			name: "invalid event message format",
+			events: []*corev1.Event{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "event-1",
+					},
+					Message:        "invalid message format",
+					FirstTimestamp: v1.Time{Time: now},
+				},
+			},
+			nodeName:      "master-1",
+			hostnameLabel: "master-1",
+			expectError:   false,
+		},
+		{
+			name: "event matches hostname label but not node name",
+			events: []*corev1.Event{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "event-1",
+					},
+					Message:        "Fencing event: reboot of hostname-1 completed with status success",
+					FirstTimestamp: v1.Time{Time: now},
+				},
+			},
+			nodeName:      "node-1.example.com",
+			hostnameLabel: "hostname-1",
+			expectError:   false,
+		},
+		{
+			name: "event matches node name but not hostname label",
+			events: []*corev1.Event{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "event-1",
+					},
+					Message:        "Fencing event: reboot of node-1.example.com completed with status success",
+					FirstTimestamp: v1.Time{Time: now},
+				},
+			},
+			nodeName:      "node-1.example.com",
+			hostnameLabel: "hostname-1",
+			expectError:   false,
+		},
+		{
+			name: "event matches neither node name nor hostname label",
+			events: []*corev1.Event{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "event-1",
+					},
+					Message:        "Fencing event: reboot of other-node completed with status success",
+					FirstTimestamp: v1.Time{Time: now},
+				},
+			},
+			nodeName:      "node-1.example.com",
+			hostnameLabel: "hostname-1",
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := getLatestPaceMakerEvent(tt.events, tt.nodeName, tt.hostnameLabel)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHandleNodeUp(t *testing.T) {
+	ctx := context.TODO()
+
+	tests := []struct {
+		name               string
+		node               *corev1.Node
+		expectedTaintCount int
+		expectAnnotation   bool
+	}{
+		{
+			name: "node with operator annotation and taints",
+			node: &corev1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						operatorAddTaintAnnotationKey: "true",
+					},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    outOfServiceTaint,
+							Value:  "nodeshutdown",
+							Effect: corev1.TaintEffectNoExecute,
+						},
+						{
+							Key:    outOfServiceTaint,
+							Value:  "nodeshutdown",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+			expectedTaintCount: 0,
+			expectAnnotation:   false,
+		},
+		{
+			name: "node without operator annotation",
+			node: &corev1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "test-node",
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    outOfServiceTaint,
+							Value:  "nodeshutdown",
+							Effect: corev1.TaintEffectNoExecute,
+						},
+					},
+				},
+			},
+			expectedTaintCount: 1,
+			expectAnnotation:   false,
+		},
+		{
+			name: "node with operator annotation and mixed taints",
+			node: &corev1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						operatorAddTaintAnnotationKey: "true",
+					},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    outOfServiceTaint,
+							Value:  "nodeshutdown",
+							Effect: corev1.TaintEffectNoExecute,
+						},
+						{
+							Key:    "custom-taint",
+							Value:  "custom-value",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+			expectedTaintCount: 1,
+			expectAnnotation:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tt.node).Build()
+
+			handleNodeUp(ctx, client, tt.node)
+
+			assert.Equal(t, tt.expectedTaintCount, len(tt.node.Spec.Taints))
+			_, exists := tt.node.Annotations[operatorAddTaintAnnotationKey]
+			assert.Equal(t, tt.expectAnnotation, exists)
+		})
+	}
+}
+
+func TestHandleNodeDown(t *testing.T) {
+	ctx := context.TODO()
+	now := time.Now()
+
+	tests := []struct {
+		name         string
+		node         *corev1.Node
+		events       []runtime.Object
+		expectUpdate bool
+	}{
+		{
+			name: "node down with valid pacemaker event",
+			node: &corev1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "master-1",
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{},
+				},
+			},
+			events: []runtime.Object{
+				&corev1.Event{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "pacemaker-event",
+						Namespace: pacemakerFencingEventNamespace,
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: pacemakerEventTriggerObjectKind,
+						Name: pacemakerEventTriggerObjectName,
+					},
+					Reason:         pacemakerFencingEventName,
+					Message:        "Fencing event: reboot of master-1 completed with status success",
+					FirstTimestamp: v1.Time{Time: now},
+				},
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "node down without pacemaker event",
+			node: &corev1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "master-1",
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{},
+				},
+			},
+			events:       []runtime.Object{},
+			expectUpdate: false,
+		},
+		{
+			name: "node already has newer annotation",
+			node: &corev1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "master-1",
+					Annotations: map[string]string{
+						pacemakerFencingEventTimeNodeAnnotationKey: now.Add(1 * time.Hour).Format(time.RFC3339Nano),
+					},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{},
+				},
+			},
+			events: []runtime.Object{
+				&corev1.Event{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "pacemaker-event",
+						Namespace: pacemakerFencingEventNamespace,
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: pacemakerEventTriggerObjectKind,
+						Name: pacemakerEventTriggerObjectName,
+					},
+					Reason:         pacemakerFencingEventName,
+					Message:        "Fencing event: reboot of master-1 completed with status success",
+					FirstTimestamp: v1.Time{Time: now},
+				},
+			},
+			expectUpdate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			allObjects := append(tt.events, tt.node)
+			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(allObjects...).Build()
+
+			result := handleNodeDown(ctx, client, tt.node)
+			assert.Equal(t, tt.expectUpdate, result)
+
+			if tt.expectUpdate {
+				assert.NotEmpty(t, tt.node.Annotations[operatorAddTaintAnnotationKey])
+				assert.NotEmpty(t, tt.node.Annotations[pacemakerFencingEventTimeNodeAnnotationKey])
+				assert.True(t, len(tt.node.Spec.Taints) > 0)
+			}
+		})
+	}
+}
+
+func TestReconcileNodeFencing(t *testing.T) {
+	ctx := context.TODO()
+
+	tests := []struct {
+		name   string
+		node   *corev1.Node
+		events []runtime.Object
+	}{
+		{
+			name: "node ready should trigger handleNodeUp",
+			node: &corev1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						operatorAddTaintAnnotationKey: "true",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+					},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    outOfServiceTaint,
+							Value:  "nodeshutdown",
+							Effect: corev1.TaintEffectNoExecute,
+						},
+					},
+				},
+			},
+			events: []runtime.Object{},
+		},
+		{
+			name: "node not ready should trigger handleNodeDown",
+			node: &corev1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "master-1",
+					Annotations: map[string]string{},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+					},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{},
+				},
+			},
+			events: []runtime.Object{
+				&corev1.Event{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "pacemaker-event",
+						Namespace: pacemakerFencingEventNamespace,
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind: pacemakerEventTriggerObjectKind,
+						Name: pacemakerEventTriggerObjectName,
+					},
+					Reason:         pacemakerFencingEventName,
+					Message:        "Fencing event: reboot of master-1 completed with status success",
+					FirstTimestamp: v1.Time{Time: time.Now()},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			allObjects := append(tt.events, tt.node)
+			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(allObjects...).Build()
+
+			reconcileNodeFencing(ctx, client, tt.node)
+		})
+	}
+}

--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -160,7 +160,10 @@ func (o *Operator) startCRDManager(context context.Context, mgrErrorCh chan erro
 
 	if o.config.NamespaceToWatch != "" {
 		mgrOpts.Cache = cache.Options{
-			DefaultNamespaces: map[string]cache.Config{o.config.NamespaceToWatch: {}},
+			DefaultNamespaces: map[string]cache.Config{
+				o.config.NamespaceToWatch: {},
+				"openshift-etcd":          {},
+			},
 		}
 	}
 


### PR DESCRIPTION
if there is fencing performed we will add a node taint to recover the rwo volumes, as by adding node out-of-service taint it will remove the volume attachments from the fenced and down node

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
