### PR TITLE
DFBUGS-6487: exporter: add log collector for ceph exporter pod

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -145,6 +145,14 @@ func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations
 				ServiceAccountName:            k8sutil.DefaultServiceAccount,
 			},
 		}
+
+		// If the log collector is enabled we add the side-car container
+		if cephCluster.Spec.LogCollector.Enabled {
+			shareProcessNamespace := true
+			deploy.Spec.Template.Spec.ShareProcessNamespace = &shareProcessNamespace
+			deploy.Spec.Template.Spec.Containers = append(deploy.Spec.Template.Spec.Containers, *controller.LogCollectorContainer("ceph-client.ceph-exporter", cephCluster.GetNamespace(), cephCluster.Spec, nil))
+		}
+
 		cephv1.GetCephExporterAnnotations(cephCluster.Spec.Annotations).ApplyToObjectMeta(&deploy.Spec.Template.ObjectMeta)
 		applyPrometheusAnnotations(cephCluster, &deploy.Spec.Template.ObjectMeta)
 


### PR DESCRIPTION
similar to other ceph pods like osd,mon,mgr,mirror pod this commit add log collector container to the main exporter pod to rotate the logs of exporter pod.


(cherry picked from commit 201f6ae1047884b6430871dcc4fdc43850e2fe19) (cherry picked from commit 3a83cbbe71477d8264b767d2880c140c5ae4a39d) (cherry picked from commit d0f77fe22035248a1cf792375c694a16b6ef47b1)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
