### PR TITLE
DFBUGS-4306: exporter: set correct DNSPolicy for rook-ceph-exporter

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -118,6 +118,10 @@ func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations
 		// to avoid fighting for the same socket file
 		deploy.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
 		hostNetwork := exporterIsHost(cephCluster)
+		dnsPolicy := corev1.DNSClusterFirst
+		if hostNetwork {
+			dnsPolicy = corev1.DNSClusterFirstWithHostNet
+		}
 		var terminationGracePeriodSeconds int64 = 2
 		deploy.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
@@ -134,6 +138,7 @@ func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations
 				Tolerations:                   tolerations,
 				RestartPolicy:                 corev1.RestartPolicyAlways,
 				HostNetwork:                   hostNetwork,
+				DNSPolicy:                     dnsPolicy,
 				Volumes:                       volumes,
 				PriorityClassName:             cephv1.GetCephExporterPriorityClassName(cephCluster.Spec.PriorityClassNames),
 				TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
@@ -110,6 +110,7 @@ func TestCreateOrUpdateCephExporter(t *testing.T) {
 	assert.Equal(t, "", podSpec.ObjectMeta.Labels["foo"])
 	assert.Equal(t, tolerations, podSpec.Spec.Tolerations)
 	assert.Equal(t, false, podSpec.Spec.HostNetwork)
+	assert.Equal(t, corev1.DNSClusterFirst, podSpec.Spec.DNSPolicy)
 	assert.Equal(t, "", podSpec.Spec.PriorityClassName)
 	assert.Equal(t, k8sutil.DefaultServiceAccount, podSpec.Spec.ServiceAccountName)
 
@@ -128,6 +129,7 @@ func TestCreateOrUpdateCephExporter(t *testing.T) {
 	assert.Equal(t, "bar", podSpec.ObjectMeta.Labels["foo"])
 	assert.Equal(t, tolerations, podSpec.Spec.Tolerations)
 	assert.Equal(t, true, podSpec.Spec.HostNetwork)
+	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, podSpec.Spec.DNSPolicy)
 	assert.Equal(t, "test-priority-class", podSpec.Spec.PriorityClassName)
 
 	t.Run("exporter config", func(t *testing.T) {


### PR DESCRIPTION
rook-ceph-exporter should use DNSPolicy ClusterFirstWithHostNet when hostNetwork is enabled

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
