### PR TITLE
security: add networkpolicy crs for rook

### DIFF
--- a/build/csv/ceph/networkpolicy.yaml
+++ b/build/csv/ceph/networkpolicy.yaml
@@ -1,0 +1,361 @@
+#################################################################################################################
+# NetworkPolicy definitions for the Rook-Ceph operator and operand pods.
+# These policies control egress (and where applicable, ingress) traffic for each Ceph daemon type.
+#
+# Egress-only rationale: CSI node plugins use hostNetwork, so their traffic arrives from node IPs
+# which cannot be matched by namespaceSelector/podSelector ingress rules. Restricting ingress would
+# require ipBlock CIDRs that are cluster-specific and fragile, so we only enforce egress on most
+# Ceph daemon pods.
+#################################################################################################################
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rook-ceph-mon
+  namespace: openshift-storage # namespace:cluster
+spec:
+  podSelector:
+    matchLabels:
+      app: rook-ceph-mon
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns # namespace:dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - protocol: TCP
+          port: 3300
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rook-ceph-osd
+  namespace: openshift-storage # namespace:cluster
+spec:
+  podSelector:
+    matchLabels:
+      app: rook-ceph-osd
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns # namespace:dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - protocol: TCP
+          port: 3300
+        - protocol: TCP
+          port: 6789
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-mgr
+      ports:
+        - protocol: TCP
+          port: 6800
+          endPort: 7300
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+      ports:
+        - protocol: TCP
+          port: 6800
+          endPort: 7300
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rook-ceph-mgr
+  namespace: openshift-storage # namespace:cluster
+spec:
+  podSelector:
+    matchLabels:
+      app: rook-ceph-mgr
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns # namespace:dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - protocol: TCP
+          port: 3300
+        - protocol: TCP
+          port: 6789
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - rook-ceph-mds
+                  - rook-ceph-osd
+      ports:
+        - protocol: TCP
+          port: 6800
+          endPort: 7300
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rook-ceph-mds
+  namespace: openshift-storage # namespace:cluster
+spec:
+  podSelector:
+    matchLabels:
+      app: rook-ceph-mds
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns # namespace:dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - protocol: TCP
+          port: 3300
+        - protocol: TCP
+          port: 6789
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - rook-ceph-osd
+                  - rook-ceph-mds
+      ports:
+        - protocol: TCP
+          port: 6800
+          endPort: 7300
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rook-ceph-exporter
+  namespace: openshift-storage # namespace:cluster
+spec:
+  podSelector:
+    matchLabels:
+      app: rook-ceph-exporter
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring # namespace:monitoring
+      ports:
+        - protocol: TCP
+          port: 9926
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns # namespace:dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - protocol: TCP
+          port: 3300
+---
+# The OSD prepare job needs node topology labels via the K8s API.
+# The API server is host-networked so it cannot be targeted by a pod/namespace
+# selector; therefore egress is unrestricted.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rook-ceph-osd-prepare
+  namespace: openshift-storage # namespace:cluster
+spec:
+  podSelector:
+    matchLabels:
+      app: rook-ceph-osd-prepare
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rook-ceph-crashcollector
+  namespace: openshift-storage # namespace:cluster
+spec:
+  podSelector:
+    matchLabels:
+      app: rook-ceph-crashcollector
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns # namespace:dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - protocol: TCP
+          port: 3300
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rook-ceph-tools
+  namespace: openshift-storage # namespace:cluster
+spec:
+  podSelector:
+    matchLabels:
+      app: rook-ceph-tools
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns # namespace:dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - protocol: TCP
+          port: 3300
+        - protocol: TCP
+          port: 6789
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-mgr
+      ports:
+        - protocol: TCP
+          port: 6800
+          endPort: 7300
+        - protocol: TCP
+          port: 9283
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+      ports:
+        - protocol: TCP
+          port: 6800
+          endPort: 7300
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-storage # namespace:cluster
+          podSelector:
+            matchLabels:
+              app: rook-ceph-rgw
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 8443

--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -1007,6 +1007,14 @@ spec:
               verbs:
                 - get
                 - create
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - update
+                - delete
           serviceAccountName: rook-ceph-system
     strategy: deployment
   installModes:

--- a/build/csv/csv-gen.sh
+++ b/build/csv/csv-gen.sh
@@ -20,6 +20,7 @@ DRBD_SETUP_SCRIPT_CONFIGMAP="../../build/csv/ceph/$PLATFORM/manifests/rook-ceph-
 DRBD_SETUP_SCRIPT_FILE="../../deploy/examples/drbd-setup.sh"
 ASSEMBLE_FILE_COMMON="../../deploy/olm/assemble/metadata-common.yaml"
 ASSEMBLE_FILE_OCP="../../deploy/olm/assemble/metadata-ocp.yaml"
+NETWORK_POLICIES_FILE="../../deploy/examples/networkpolicy.yaml"
 
 LATEST_ROOK_CSI_CEPH_IMAGE="quay.io/cephcsi/cephcsi:v3.10.2"
 LATEST_ROOK_CSI_REGISTRAR_IMAGE="registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0"
@@ -146,6 +147,18 @@ function generate_csv() {
     sed -i'.bak' -e "s|$LATEST_ROOK_CSIADDONS_IMAGE|$ROOK_CSIADDONS_IMAGE|g" "$CSV_FILE_NAME"
 
     rm "$CSV_FILE_NAME.bak"
+
+    # Generate NetworkPolicy manifests for the OLM bundle from the upstream source.
+    # OLM sets metadata.namespace automatically (same as common.yaml).
+    # Only the namespaceSelector label values inside the spec need replacing.
+    if [ -f "$NETWORK_POLICIES_FILE" ]; then
+        echo "=== generating NetworkPolicy manifests for bundle"
+        sed -e 's|kubernetes.io/metadata.name: kube-system|kubernetes.io/metadata.name: openshift-dns|g' \
+            -e 's|kubernetes.io/metadata.name: rook-ceph|kubernetes.io/metadata.name: openshift-storage|g' \
+            -e 's|kubernetes.io/metadata.name: monitoring|kubernetes.io/metadata.name: openshift-monitoring|g' \
+            -e 's|namespace: rook-ceph # namespace:cluster|namespace: openshift-storage # namespace:cluster|g' \
+            "$NETWORK_POLICIES_FILE" > "../../build/csv/ceph/$PLATFORM/manifests/networkpolicy.yaml"
+    fi
 
     mv "../../build/csv/ceph/$PLATFORM/manifests/"* "../../build/csv/ceph/"
     rm -rf "../../build/csv/ceph/$PLATFORM"

--- a/deploy/charts/rook-ceph/templates/role.yaml
+++ b/deploy/charts/rook-ceph/templates/role.yaml
@@ -60,4 +60,12 @@ rules:
     verbs:
       - get
       - create
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - update
+      - delete
 {{- end }}

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -828,6 +828,14 @@ rules:
     verbs:
       - get
       - create
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - update
+      - delete
 ---
 # Allow the operator to create resources in this cluster's namespace
 kind: RoleBinding

--- a/deploy/examples/kustomization.yaml
+++ b/deploy/examples/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: rook-ceph
 resources:
   - crds.yaml
   - common.yaml
+  - networkpolicy.yaml
   - operator-openshift.yaml
   - external-cluster-script-configmap.yaml
   - drbd-setup-script-configmap.yaml


### PR DESCRIPTION
## Summary
Add NetworkPolicy manifests for Rook-Ceph pods and
integrate them into the OLM bundle via csv-gen.sh.
Part of [RHSTOR-7664](https://redhat.atlassian.net/browse/RHSTOR-7664) / OCPSTRAT-819.
## Changes
- 9 NetworkPolicy YAMLs in deploy/olm/networkpolicies/:
  operator, mon, osd, mgr, mds, exporter,
  osd-prepare, crashcollector, tools
- csv-gen.sh copies them into bundle manifests dir
## Design Notes
- Egress-only for most Ceph daemons: CSI plugins use
  hostNetwork, making ingress rules impractical.
- Operator pod gets allow-all egress since API server
  is host-networked with variable IP/port.
- No hardcoded metadata.namespace (OLM sets it).
- namespaceSelectors reference openshift-storage for
  pod-to-pod egress within the operand namespace.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
