### PR TITLE
update install modes

### DIFF
--- a/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
+++ b/build/csv/ceph/rook-ceph-operator.clusterserviceversion.yaml
@@ -1013,11 +1013,11 @@ spec:
     - type: OwnNamespace
       supported: true
     - type: SingleNamespace
-      supported: true
+      supported: false
     - type: MultiNamespace
       supported: false
     - type: AllNamespaces
-      supported: false
+      supported: true
   keywords:
     - rook
     - ceph

--- a/deploy/olm/assemble/metadata-common.yaml
+++ b/deploy/olm/assemble/metadata-common.yaml
@@ -48,11 +48,11 @@ spec:
     - type: OwnNamespace
       supported: true
     - type: SingleNamespace
-      supported: true
+      supported: false
     - type: MultiNamespace
       supported: false
     - type: AllNamespaces
-      supported: false
+      supported: true
   relatedImages:
     - image: docker.io/rook/ceph:master
       name: rook-container


### PR DESCRIPTION
odf-operator is moving towards olm v1, These install modes work for both olm v0 and v1. (existing odf and new odf)

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

