### PR TITLE
[wip] manifest: add DRBD upgrade post-upgrade restore steps

### DIFF
--- a/deploy/examples/drbd-setup.sh
+++ b/deploy/examples/drbd-setup.sh
@@ -45,9 +45,9 @@ _wait_succeeded() {
 }
 
 # TODO: bump default image tag when a new one is published.
-DRBD_IMAGE="${DRBD_IMAGE:-quay.io/rhceph-dev/odf4-odf-drbd-rhel9:v4.22}" # ODF DRBD image (drbdadm + sources)
+DRBD_IMAGE="${DRBD_IMAGE:-quay.io/rhceph-dev/odf4-odf-drbd-rhel9:v4.22.0}" # ODF DRBD image (drbdadm + sources)
 # TODO: bump when tarball inside the image changes.
-DRBD_VERSION="${DRBD_VERSION:-9.2.17}"                                   # Must match DRBD source version in DRBD_IMAGE
+DRBD_VERSION="${DRBD_VERSION:-9.2.18}"                                   # Must match DRBD source version in DRBD_IMAGE
 
 DRBD_CONF_PATH="${DRBD_CONF_PATH:-/etc/drbd.conf}"               # Main file: include of ${DRBD_DIR_PATH}/*.res only
 DRBD_DIR_PATH="${DRBD_DIR_PATH:-/etc/drbd.d}"                    # Per-resource .res files (actual DRBD definition)
@@ -622,15 +622,13 @@ kmm_image_build_waits() {
     fi
 }
 
-# create the KMM Module CR and dockerfile ConfigMap to build and load DRBD kernel modules on the nodes.
-create_drbd_module() {
-    if oc get module drbd-kmod -n openshift-kmm &>/dev/null; then
-        msg "KMM Module drbd-kmod already exists."
-        return 0
-    fi
+# Lowercase DRBD_VERSION with dots/pluses turned into dashes for a distinct in-registry kmod image tag per release.
+drbd_kmod_image_tag_version_fragment() {
+    printf '%s' "$DRBD_VERSION" | tr '[:upper:]' '[:lower:]' | tr '.+' '--'
+}
 
-    msg "Creating KMM Module drbd-kmod"
-
+# Build the KMM Dockerfile body (DRBD_VERSION / DRBD_IMAGE substituted).
+render_drbd_kmm_dockerfile() {
     local kmm_dockerfile
     kmm_dockerfile=$(cat <<'DOCKERFILE_TEMPLATE'
     ARG DTK_AUTO
@@ -660,6 +658,21 @@ DOCKERFILE_TEMPLATE
 )
     kmm_dockerfile="${kmm_dockerfile//__DRBD_VERSION__/${DRBD_VERSION}}"
     kmm_dockerfile="${kmm_dockerfile//__DRBD_IMAGE__/${DRBD_IMAGE}}"
+    printf '%s\n' "$kmm_dockerfile"
+}
+
+# Create the KMM Module CR and dockerfile ConfigMap to build and load DRBD kernel modules on the nodes.
+create_drbd_module() {
+    if oc get module drbd-kmod -n openshift-kmm &>/dev/null; then
+        msg "KMM Module drbd-kmod already exists."
+        return 0
+    fi
+
+    local kmm_dockerfile drbd_tag_frag
+    kmm_dockerfile=$(render_drbd_kmm_dockerfile)
+    drbd_tag_frag=$(drbd_kmod_image_tag_version_fragment)
+
+    msg "Creating KMM Module drbd-kmod"
 
     oc apply -f - >/dev/null <<EOF
 apiVersion: v1
@@ -672,7 +685,8 @@ data:
 $(printf '%s\n' "$kmm_dockerfile" | awk '{print "    " $0}')
 EOF
 
-    oc apply -f - >/dev/null <<'MODULE_SPEC'
+    # Include DRBD version in the image tag so old images are not reused.
+    oc apply -f - >/dev/null <<EOF
 apiVersion: kmm.sigs.x-k8s.io/v1beta1
 kind: Module
 metadata:
@@ -686,12 +700,12 @@ spec:
         dirName: /opt
       kernelMappings:
         - regexp: '^.*\.x86_64$'
-          containerImage: 'image-registry.openshift-image-registry.svc:5000/openshift-kmm/drbd_compat_kmod:${KERNEL_FULL_VERSION}'
+          containerImage: "image-registry.openshift-image-registry.svc:5000/openshift-kmm/drbd_compat_kmod:\${KERNEL_FULL_VERSION}-drbd-${drbd_tag_frag}"
           build:
             dockerfileConfigMap:
               name: drbd-kmod-dockerfile
   selector: {}
-MODULE_SPEC
+EOF
     msg "KMM Module and ConfigMap applied."
 }
 
@@ -725,7 +739,7 @@ wait_for_modules() {
         return 0
     fi
 
-    # Success: /proc/modules on each node contains drbd and drbd_transport_tcp lines (see node_has_drbd_kmods).
+    # Success: /proc/modules on each node contains drbd and drbd_transport_tcp lines
     msg "Waiting for DRBD kernel modules to load on both nodes (up to 10 min)..."
     _wait_begin
     local i
@@ -739,6 +753,17 @@ wait_for_modules() {
         fi
         sleep 10
     done
+}
+
+# Validate loaded /sys/module/drbd/version against DRBD_VERSION on both nodes.
+validate_drbd_module_version() {
+    local v0 v1
+    v0=$(oc debug -q "node/$NODE_0" -- chroot /host cat /sys/module/drbd/version 2>/dev/null | tr -d '[:space:]' || true)
+    v1=$(oc debug -q "node/$NODE_1" -- chroot /host cat /sys/module/drbd/version 2>/dev/null | tr -d '[:space:]' || true)
+    if [[ "$v0" != "$DRBD_VERSION" || "$v1" != "$DRBD_VERSION" ]]; then
+        die "loaded DRBD kmod version mismatch after module load: expected ${DRBD_VERSION}, got ${NODE_0}='${v0}' ${NODE_1}='${v1}'."
+    fi
+    msg "Loaded DRBD kmod version matches target version (${DRBD_VERSION}) on both nodes."
 }
 
 # Run drbdadm on a node via podman using the DRBD image; mounts host drbd.conf and drbd.d.
@@ -761,16 +786,20 @@ drbdctl() {
 
 # True when the node has a role (Primary/Secondary) for the DRBD resource.
 drbd_node_has_role() {
-    local node="$1" status_out
-    if ! status_out=$(drbdctl "$node" status "${DRBD_RESOURCE}" 2>&1); then
-        return 1
-    fi
-    echo "$status_out" | grep -qiE 'role:[[:space:]]*(Primary|Secondary)'
+    local node="$1" role
+    role=$(drbdctl "$node" role "${DRBD_RESOURCE}" 2>/dev/null || true)
+    [[ "$role" == "Primary" || "$role" == "Secondary" || "$role" == Primary/* || "$role" == Secondary/* ]]
 }
 
 # True when both nodes show a role (Primary/Secondary) for the DRBD resource.
 drbd_resource_up_on_both_nodes() {
-    drbd_node_has_role "$NODE_0" && drbd_node_has_role "$NODE_1"
+    local node
+    for node in "$NODE_0" "$NODE_1"; do
+        if ! drbd_node_has_role "$node"; then
+            return 1
+        fi
+    done
+    return 0
 }
 
 # configure the DRBD resource on both nodes
@@ -810,28 +839,51 @@ resource ${DRBD_RESOURCE} {
 
     local node res_path
     res_path="${DRBD_DIR_PATH}/${DRBD_RESOURCE}.res"
+
+    # Write DRBD config files on both hosts before any drbdadm mutate
     for node in "$NODE_0" "$NODE_1"; do
         msg "Node ${node}: writing DRBD config files to the host..."
         if ! oc debug -q "node/$node" -- chroot /host bash -c "
-mkdir -p \"$(dirname "${DRBD_CONF_PATH}")\" '${DRBD_DIR_PATH}' /var/lib/drbd
-echo '${DRBD_RES_B64}' | base64 -d > '${res_path}'
-echo '${DRBD_MAIN_B64}' | base64 -d > '${DRBD_CONF_PATH}'
-"; then
+            mkdir -p \"$(dirname "${DRBD_CONF_PATH}")\" '${DRBD_DIR_PATH}' /var/lib/drbd
+            echo '${DRBD_RES_B64}' | base64 -d > '${res_path}'
+            echo '${DRBD_MAIN_B64}' | base64 -d > '${DRBD_CONF_PATH}'
+        "; then
             die "failed to write DRBD config on $node"
         fi
+    done
 
+    # Upgrade: metadata already exists
+    for node in "$NODE_0" "$NODE_1"; do
         if drbd_node_has_role "$node"; then
-            msg "Node ${node}: resource already has a role on this host; running drbdadm adjust..."
-            if ! drbdctl "$node" adjust "${DRBD_RESOURCE}"; then
-                die "drbdadm adjust failed on $node"
+            continue
+        fi
+        if [[ "$MODE" == "upgrade" ]]; then
+            msg "Node ${node}: drbdadm up"
+            if ! drbdctl "$node" up "${DRBD_RESOURCE}"; then
+                die "drbdadm up failed on $node"
             fi
         else
-            msg "Node ${node}: creating DRBD metadata then drbdadm up..."
+            msg "Node ${node}: drbdadm create-md"
             if ! drbdctl "$node" create-md "${DRBD_RESOURCE}" --force; then
                 die "drbdadm create-md failed on $node"
             fi
+            msg "Node ${node}: drbdadm up"
             if ! drbdctl "$node" up "${DRBD_RESOURCE}"; then
-                die "drbdadm up failed on $node"
+                msg "Node ${node}: drbdadm up failed; retrying after drbdadm down..."
+                drbdctl "$node" down "${DRBD_RESOURCE}" 2>/dev/null || true
+                if ! drbdctl "$node" up "${DRBD_RESOURCE}"; then
+                    die "drbdadm up failed on $node"
+                fi
+            fi
+        fi
+    done
+
+    # Running adjust on both nodes reapplies .res to the running resource
+    for node in "$NODE_0" "$NODE_1"; do
+        if drbd_node_has_role "$node"; then
+            msg "Node ${node}: drbdadm adjust"
+            if ! drbdctl "$node" adjust "${DRBD_RESOURCE}"; then
+                die "drbdadm adjust failed on $node"
             fi
         fi
     done
@@ -902,7 +954,7 @@ create_filesystem_over_drbd() {
         fstype=""
     fi
     if [[ "$fstype" == "xfs" ]]; then
-        msg "${DRBD_DEVICE} already has XFS; skipping mkfs (re-run safe)."
+        msg "${DRBD_DEVICE} already has XFS; skipping mkfs."
         return 0
     fi
 
@@ -1210,9 +1262,9 @@ main() {
     fi
 
     if [[ "$MODE" == "upgrade" ]]; then
-        validate_upgrade_configmap_and_load_disk_ids
+        validate_upgrade_configmap_and_load_disk_ids # upgrade only: validate output ConfigMap presence and load DRBD disk by-id mapping
     else
-        validate_and_resolve_disks # validate paths and resolve to /dev/disk/by-id
+        validate_and_resolve_disks # install only: validate paths and resolve to /dev/disk/by-id
     fi
 
     print_config # print the configuration
@@ -1221,21 +1273,28 @@ main() {
     kmm_image_build_waits # wait for builder SA + dockercfg secret
 
     if [[ "$MODE" == "upgrade" ]]; then
-        scale_floating_mon_deployment 0
+        # Add do not reconcile flag
+        scale_floating_mon_deployment 0 # scale the floating mon deployment down to 0 replicas
         msg "Waiting 10s after scaling floating mon (I/O drain)..."
         sleep 10
-        delete_drbd_autostart_daemonset
-        drbd_demote_and_down_all
-        delete_drbd_kmm_module_resources
+        delete_drbd_autostart_daemonset # delete the DRBD auto-start DaemonSet
+        drbd_demote_and_down_all # demote and down the DRBD resource on both nodes
+        delete_drbd_kmm_module_resources # delete the KMM Module and Dockerfile ConfigMap
     fi
 
-    create_drbd_module # create the KMM Module CR and dockerfile ConfigMap to build and load DRBD kernel modules on the nodes
-    wait_for_modules # wait for the DRBD kernel modules to load on both nodes
+    create_drbd_module # common path: create KMM Module + Dockerfile ConfigMap
+    wait_for_modules # wait for DRBD kernel modules to load on both nodes
+    validate_drbd_module_version # compare /sys/module/drbd/version to DRBD_VERSION
     configure_drbd # configure the DRBD resource on both nodes
     sync_drbd # sync the DRBD resource on both nodes
     create_filesystem_over_drbd # create the filesystem over the DRBD device
     make_both_node_secondary # make both nodes secondary
     setup_drbd_autostart # setup the DRBD auto-start DaemonSet to keep the DRBD resource up on both nodes
+
+    if [[ "$MODE" == "upgrade" ]]; then
+        scale_floating_mon_deployment 1
+    fi
+
     create_success_configmap # create the success ConfigMap to save the setup summary for further consumption
     print_success # print the success message
 }

--- a/deploy/examples/drbd-setup.sh
+++ b/deploy/examples/drbd-setup.sh
@@ -332,6 +332,24 @@ done | sort -u | head -n 1
 ' 2>/dev/null | tail -n 1
 }
 
+# Validate upgrade ConfigMap and load only DRBD lower-layer by-id mapping.
+validate_upgrade_configmap_and_load_disk_ids() {
+    msg "Validating ConfigMap ${ODF_NAMESPACE}/${OUTPUT_CM_NAME} and loading DISK_BY_ID mapping..."
+    if ! oc get configmap "${OUTPUT_CM_NAME}" -n "${ODF_NAMESPACE}" &>/dev/null; then
+        die "ConfigMap ${ODF_NAMESPACE}/${OUTPUT_CM_NAME} not found. Run default setup first: $0 -d <path>"
+    fi
+
+    DISK_RESOLVED_NODE0=$(oc get configmap "${OUTPUT_CM_NAME}" -n "${ODF_NAMESPACE}" \
+        -o jsonpath='{.data.DISK_BY_ID_NODE_0}' | tr -d '\r\n') \
+        || die "failed reading DISK_BY_ID_NODE_0 from ConfigMap ${OUTPUT_CM_NAME}"
+    DISK_RESOLVED_NODE1=$(oc get configmap "${OUTPUT_CM_NAME}" -n "${ODF_NAMESPACE}" \
+        -o jsonpath='{.data.DISK_BY_ID_NODE_1}' | tr -d '\r\n') \
+        || die "failed reading DISK_BY_ID_NODE_1 from ConfigMap ${OUTPUT_CM_NAME}"
+    if [[ -z "$DISK_RESOLVED_NODE0" || -z "$DISK_RESOLVED_NODE1" ]]; then
+        die "ConfigMap ${OUTPUT_CM_NAME}: missing DISK_BY_ID_NODE_0 or DISK_BY_ID_NODE_1"
+    fi
+}
+
 print_config() {
     echo ""
     msg "Configuration"
@@ -343,8 +361,8 @@ print_config() {
     fi
     printf '  %-*s %s\n' "$_lw" "Nodes:" "$NODE_0 ($NODE_0_IP), $NODE_1 ($NODE_1_IP)"
     if [[ "$MODE" == "upgrade" ]]; then
-        printf '  %-*s %s: %s\n' "$_lw" "DRBD disks by id:" "$NODE_0" "${DISK_RESOLVED_NODE0:-<from ConfigMap>}"
-        printf '  %-*s %s: %s\n' "$_lw" "(from ConfigMap)" "$NODE_1" "${DISK_RESOLVED_NODE1:-<from ConfigMap>}"
+        printf '  %-*s %s: %s\n' "$_lw" "DRBD disks by id:" "$NODE_0" "$DISK_RESOLVED_NODE0"
+        printf '  %-*s %s: %s\n' "$_lw" "(from ConfigMap)" "$NODE_1" "$DISK_RESOLVED_NODE1"
     elif [[ -n "$BACKING_PATH" ]]; then
         printf '  %-*s %s (same path on both nodes)\n' "$_lw" "Backing device:" "$BACKING_PATH"
     else
@@ -675,6 +693,13 @@ spec:
   selector: {}
 MODULE_SPEC
     msg "KMM Module and ConfigMap applied."
+}
+
+# Remove KMM objects so the next apply triggers a rebuild (upgrade path).
+delete_drbd_kmm_module_resources() {
+    msg "Deleting KMM Module drbd-kmod and Dockerfile ConfigMap"
+    oc delete module drbd-kmod -n openshift-kmm --ignore-not-found >/dev/null
+    oc delete configmap drbd-kmod-dockerfile -n openshift-kmm --ignore-not-found >/dev/null
 }
 
 # check if the DRBD kernel modules are loaded on the node
@@ -1049,6 +1074,71 @@ EOF
     done
 }
 
+# Label on the floating mon Deployment so the Rook operator does not reconcile it while scaled down for DRBD upgrade.
+FLOATING_MON_NO_RECONCILE_LABEL_KEY="${FLOATING_MON_NO_RECONCILE_LABEL_KEY:-ceph.rook.io/do-not-reconcile}"
+FLOATING_MON_NO_RECONCILE_LABEL_VALUE="${FLOATING_MON_NO_RECONCILE_LABEL_VALUE:-true}"
+
+# Return deployment name rook-ceph-mon-<floatingMon> or empty if not applicable.
+floating_mon_deployment_name() {
+    local name
+    name=$(oc get cephcluster -n "${ODF_NAMESPACE}" -o jsonpath='{.items[0].spec.mon.floatingMon.name}' 2>/dev/null || true)
+    if [[ -z "$name" ]]; then
+        echo ""
+        return 1
+    fi
+    echo "rook-ceph-mon-${name}"
+}
+
+# Scale the floating mon deployment to the given number of replicas.
+# Before scale to 0: set ceph.rook.io/do-not-reconcile=true on the Deployment so Rook does not fight the scale.
+# Before scale up (replicas > 0): remove that label, then scale.
+scale_floating_mon_deployment() {
+    local replicas="$1" dep
+    dep=$(floating_mon_deployment_name || true)
+    if [[ -z "$dep" ]]; then
+        msg "No CephCluster floating mon in ${ODF_NAMESPACE}; skipping mon deployment scale."
+        return 0
+    fi
+    if ! oc get deployment "$dep" -n "${ODF_NAMESPACE}" &>/dev/null; then
+        msg "Deployment ${ODF_NAMESPACE}/${dep} not found; skipping mon scale."
+        return 0
+    fi
+    if [[ "${replicas}" -eq 0 ]]; then
+        msg "Labeling deployment ${ODF_NAMESPACE}/${dep} ${FLOATING_MON_NO_RECONCILE_LABEL_KEY}=${FLOATING_MON_NO_RECONCILE_LABEL_VALUE} (do not reconcile)..."
+        oc label deployment "$dep" -n "${ODF_NAMESPACE}" \
+            "${FLOATING_MON_NO_RECONCILE_LABEL_KEY}=${FLOATING_MON_NO_RECONCILE_LABEL_VALUE}" --overwrite
+    else
+        msg "Removing label ${FLOATING_MON_NO_RECONCILE_LABEL_KEY} from deployment ${ODF_NAMESPACE}/${dep}..."
+        oc label deployment "$dep" -n "${ODF_NAMESPACE}" "${FLOATING_MON_NO_RECONCILE_LABEL_KEY}-" 2>/dev/null || true
+    fi
+    msg "Scaling deployment ${ODF_NAMESPACE}/${dep} to ${replicas} replica(s)..."
+    oc scale deployment "$dep" -n "${ODF_NAMESPACE}" --replicas="${replicas}"
+}
+
+# Delete the DRBD auto-start DaemonSet.
+delete_drbd_autostart_daemonset() {
+    if ! oc get daemonset "${AUTOSTART_DAEMONSET_NAME}" -n "${AUTOSTART_DAEMONSET_NS}" &>/dev/null; then
+        return 0
+    fi
+    msg "Deleting DaemonSet ${AUTOSTART_DAEMONSET_NS}/${AUTOSTART_DAEMONSET_NAME}..."
+    oc delete daemonset "${AUTOSTART_DAEMONSET_NAME}" -n "${AUTOSTART_DAEMONSET_NS}" --ignore-not-found >/dev/null
+}
+
+# Demote and down the DRBD resource on both nodes.
+drbd_demote_and_down_all() {
+    local node role
+    msg "Stopping DRBD resource on both nodes"
+    for node in "$NODE_0" "$NODE_1"; do
+        role=$(drbdctl "$node" role "${DRBD_RESOURCE}" 2>/dev/null | cut -d/ -f1 | tr -d '[:space:]' || true)
+        if [[ "$role" == "Primary" ]]; then
+            msg "Node ${node}: demoting Primary before drbdadm down..."
+            drbdctl "$node" secondary "${DRBD_RESOURCE}" || true
+        fi
+        msg "Node ${node}: drbdadm down ${DRBD_RESOURCE}..."
+        drbdctl "$node" down "${DRBD_RESOURCE}" || true
+    done
+}
+
 # create the success ConfigMap to save the setup summary for further consumption.
 create_success_configmap() {
     msg "Saving setup summary to ConfigMap ${ODF_NAMESPACE}/${OUTPUT_CM_NAME}"
@@ -1119,11 +1209,26 @@ main() {
         exit 0
     fi
 
+    if [[ "$MODE" == "upgrade" ]]; then
+        validate_upgrade_configmap_and_load_disk_ids
+    else
+        validate_and_resolve_disks # validate paths and resolve to /dev/disk/by-id
+    fi
+
     print_config # print the configuration
-    validate_and_resolve_disks # validate the disks and resolve the disk by-id symlink for DRBD config on that node
-    setup_kmm_operator # setup the KMM operator
-    setup_image_registry_operator # setup the image registry operator
-    kmm_image_build_waits # wait for the ServiceAccount builder and the builder dockercfg Secret to be populated
+    setup_kmm_operator # setup the Kernel Module Management operator
+    setup_image_registry_operator # setup the Image Registry operator
+    kmm_image_build_waits # wait for builder SA + dockercfg secret
+
+    if [[ "$MODE" == "upgrade" ]]; then
+        scale_floating_mon_deployment 0
+        msg "Waiting 10s after scaling floating mon (I/O drain)..."
+        sleep 10
+        delete_drbd_autostart_daemonset
+        drbd_demote_and_down_all
+        delete_drbd_kmm_module_resources
+    fi
+
     create_drbd_module # create the KMM Module CR and dockerfile ConfigMap to build and load DRBD kernel modules on the nodes
     wait_for_modules # wait for the DRBD kernel modules to load on both nodes
     configure_drbd # configure the DRBD resource on both nodes

--- a/deploy/examples/drbd-setup.sh
+++ b/deploy/examples/drbd-setup.sh
@@ -17,11 +17,9 @@
 # DRBD Setup Script for Two-Node OpenShift Cluster, Safe to re-run( idempotent ).
 # The script can skip successful steps & run only the required steps.
 #
-# CLI overrides env for: --drbd-conf-path, --drbd-dir-path, --drbd-resource, --drbd-device, --drbd-port
-#
 # Prerequisites:
-#   - Nodes can pull ${DRBD_IMAGE}; ${DRBD_PORT}/tcp open between nodes.
-#   - Image registry: the in-cluster OpenShift registry with emptyDir storage
+#   - Nodes can pull ${DRBD_IMAGE};
+#   - ${DRBD_PORT}/tcp open between nodes.
 #
 set -euo pipefail
 
@@ -60,8 +58,13 @@ DRBD_PORT="${DRBD_PORT:-7794}"                                   # DRBD replicat
 AUTOSTART_DAEMONSET_NAME="${AUTOSTART_DAEMONSET_NAME:-drbd-autostart}" # DRBD auto-start DaemonSet name
 AUTOSTART_DAEMONSET_NS="${AUTOSTART_DAEMONSET_NS:-openshift-kmm}"      # DRBD auto-start DaemonSet namespace
 
-OUTPUT_CM_NS="${OUTPUT_CM_NS:-openshift-storage}"                # Namespace for setup summary ConfigMap
 OUTPUT_CM_NAME="${OUTPUT_CM_NAME:-drbd-configure}"               # Name for the setup summary ConfigMap
+
+# OpenShift namespace for DRBD summary ConfigMap, CephCluster, and floating mon (default OpenShift ODF).
+ODF_NAMESPACE="${ODF_NAMESPACE:-openshift-storage}"
+
+# install | upgrade (set in parse_args; default install)
+MODE=""
 
 # Approximate wait ceilings in this script: KMM operator ~5m (60×5s); DRBD modules ~10m (60×10s);
 # initial sync ~30m (60×30s); autostart DaemonSet ~5m (60×5s).
@@ -85,46 +88,51 @@ NODE_1_IP=""
 
 usage() {
     cat <<USAGE
-Usage:
-  $0 -d <path>
-  $0 -d0 <path0> -d1 <path1>
-  $0 -l
+Usage examples:
+  $0 -l | $0 -d <path> | $0 -d0 <path> -d1 <path> | $0 upgrade | $0 help
+
+Default Mode (install) —
+
+Required (one of):
+  -l                  List block devices on each node (NAME, PATH, SIZE, ROTA, TYPE, FSTYPE).
+  -d PATH             Backing block device, same path & size on both nodes (e.g. /dev/sdb).
+  -d0 PATH -d1 PATH   Per-node backing paths (node order = sorted cluster node names).
+
+Optional:
+  --drbd-conf-path PATH   Host path to drbd.conf (default ${DRBD_CONF_PATH})
+  --drbd-dir-path PATH    Host dir for resource snippets (default ${DRBD_DIR_PATH})
+  --drbd-resource NAME    Resource name in config (default ${DRBD_RESOURCE})
+  --drbd-device PATH      Upper DRBD device (default ${DRBD_DEVICE})
+  --drbd-port N           TCP replication port (default ${DRBD_PORT})
 
 Backing paths are raw block device paths (e.g. /dev/sdb). Use the PATH column from -l.
 Disks must be SSD-class (ROTA 0) and same size on both nodes.
 
-  -d PATH
-      One path used on both nodes. Choose this when each machine has the replica disk at the
-      same device name (both nodes use e.g. /dev/sdb for the DRBD lower layer).
+What install does: setup KMM operator, setup image registry operator,
+build and load DRBD kmods, configure & sync DRBD, create the filesystem over the DRBD device,
+setup the DRBD auto-start DaemonSet & create the success ConfigMap.
 
-Use -d0/-d1 when the two nodes use different paths; do not combine -d with -d0/-d1.
+Upgrade Mode —
 
-  -d0 PATH   Path on node 0 only (first node name after sorting all cluster nodes).
-  -d1 PATH   Path on node 1 only (second node).
+(no disk flags — DISK_BY_ID_NODE_0/1 are read from ConfigMap ${ODF_NAMESPACE}/${OUTPUT_CM_NAME})
 
-Discovery:
-  -l    List block devices on each node (NAME, PATH, SIZE, ROTA, TYPE, FSTYPE).
-
-DRBD options:
-  --drbd-conf-path PATH  Host path to drbd.conf (default ${DRBD_CONF_PATH})
-  --drbd-dir-path PATH   Host dir for resource snippets (default ${DRBD_DIR_PATH})
-  --drbd-resource NAME   Logical DRBD resource name in config (default ${DRBD_RESOURCE})
-  --drbd-device PATH     DRBD upper device node path, same on both nodes (default ${DRBD_DEVICE})
-  --drbd-port N          TCP port for DRBD replication (default ${DRBD_PORT})
+What upgrade does: scale floating Ceph mon, remove autostart DaemonSet, drbdadm down,
+delete and re-apply KMM Module + Dockerfile, wait for new kmods, drbdadm up, sync if needed,
+recreate autostart DaemonSet, scale mon back.
 
 General:
-  -h    Show this help and exit
-
-Environment:
-  Defaults are documented on each assignment near the top of this script.
-  OUTPUT_CM_NS / OUTPUT_CM_NAME — namespace and name of the summary ConfigMap (floating mon).
+  -h, --help   Show this text.
 
 USAGE
 }
 
-parse_args() {
+_parse_install_options() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
             -d0)
                 if [[ -z "${2:-}" ]]; then
                     die "-d0 requires a path (e.g. /dev/sdb)"
@@ -185,17 +193,55 @@ parse_args() {
                 DRBD_PORT="$2"
                 shift 2
                 ;;
-            -h)
-                usage
-                exit 0
-                ;;
             *)
                 die "Unknown option: $1 (use -h)"
                 ;;
         esac
     done
+}
+
+parse_args() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+        usage
+        exit 0
+    fi
+
+    if [[ $# -eq 0 ]]; then
+        MODE="install"
+    elif [[ "$1" == "help" ]]; then
+        usage
+        exit 0
+    elif [[ "$1" == "upgrade" ]]; then
+        MODE="upgrade"
+        shift
+        if [[ $# -eq 0 ]]; then
+            :
+        elif [[ "$1" == "-h" || "$1" == "--help" ]]; then
+            usage
+            exit 0
+        else
+            die "upgrade accepts no arguments (got '$1'). See: $0 upgrade -h"
+        fi
+    elif [[ "$1" == "install" ]]; then
+        MODE="install"
+        shift
+        _parse_install_options "$@"
+    else
+        MODE="install"
+        _parse_install_options "$@"
+    fi
 
     if [[ "$LIST_DEVICES_ONLY" -eq 1 ]]; then
+        if [[ "$MODE" == "upgrade" ]]; then
+            die "upgrade does not support -l (use: $0 -l for device discovery)"
+        fi
+        return 0
+    fi
+
+    if [[ "$MODE" == "upgrade" ]]; then
+        if [[ -n "$BACKING_PATH" || -n "$BACKING_PATH_NODE0" || -n "$BACKING_PATH_NODE1" ]]; then
+            die "upgrade does not use -d/-d0/-d1; use ConfigMap ${ODF_NAMESPACE}/${OUTPUT_CM_NAME} (from default setup). Run: $0 upgrade"
+        fi
         return 0
     fi
 
@@ -290,8 +336,16 @@ print_config() {
     echo ""
     msg "Configuration"
     local _lw=18
+    if [[ "$MODE" == "upgrade" ]]; then
+        printf '  %-*s %s\n' "$_lw" "Mode:" "upgrade (KMM kmod refresh; preserve DRBD metadata)"
+    else
+        printf '  %-*s %s\n' "$_lw" "Mode:" "install (KMM + DRBD resource + success ConfigMap)"
+    fi
     printf '  %-*s %s\n' "$_lw" "Nodes:" "$NODE_0 ($NODE_0_IP), $NODE_1 ($NODE_1_IP)"
-    if [[ -n "$BACKING_PATH" ]]; then
+    if [[ "$MODE" == "upgrade" ]]; then
+        printf '  %-*s %s: %s\n' "$_lw" "DRBD disks by id:" "$NODE_0" "${DISK_RESOLVED_NODE0:-<from ConfigMap>}"
+        printf '  %-*s %s: %s\n' "$_lw" "(from ConfigMap)" "$NODE_1" "${DISK_RESOLVED_NODE1:-<from ConfigMap>}"
+    elif [[ -n "$BACKING_PATH" ]]; then
         printf '  %-*s %s (same path on both nodes)\n' "$_lw" "Backing device:" "$BACKING_PATH"
     else
         printf '  %-*s %s\n' "$_lw" "Backing devices:" "per-node paths"
@@ -303,6 +357,8 @@ print_config() {
     printf '  %-*s %s\n' "$_lw" "DRBD Resource:" "$DRBD_RESOURCE"
     printf '  %-*s %s\n' "$_lw" "DRBD Device:" "$DRBD_DEVICE"
     printf '  %-*s %s\n' "$_lw" "DRBD Port:" "$DRBD_PORT"
+    printf '  %-*s %s\n' "$_lw" "DRBD_IMAGE:" "$DRBD_IMAGE"
+    printf '  %-*s %s\n' "$_lw" "DRBD_VERSION:" "$DRBD_VERSION"
     echo ""
 }
 
@@ -995,8 +1051,8 @@ EOF
 
 # create the success ConfigMap to save the setup summary for further consumption.
 create_success_configmap() {
-    msg "Saving setup summary to ConfigMap ${OUTPUT_CM_NS}/${OUTPUT_CM_NAME}"
-    if ! oc create namespace "${OUTPUT_CM_NS}" --dry-run=client -o yaml | oc apply -f - >/dev/null 2>&1; then
+    msg "Saving setup summary to ConfigMap ${ODF_NAMESPACE}/${OUTPUT_CM_NAME}"
+    if ! oc create namespace "${ODF_NAMESPACE}" --dry-run=client -o yaml | oc apply -f - >/dev/null 2>&1; then
         :
     fi
 
@@ -1014,7 +1070,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ${OUTPUT_CM_NAME}
-  namespace: ${OUTPUT_CM_NS}
+  namespace: ${ODF_NAMESPACE}
   labels:
     app.kubernetes.io/name: drbd-setup
     app.kubernetes.io/component: storage
@@ -1040,9 +1096,13 @@ EOF
 
 print_success() {
     echo ""
-    echo "  --> DRBD setup completed successfully <--"
+    if [[ "$MODE" == "upgrade" ]]; then
+        echo "  --> DRBD upgrade completed successfully <--"
+    else
+        echo "  --> DRBD install completed successfully <--"
+    fi
     echo ""
-    echo "Post-install DRBD status on ${NODE_0} (repeat with ${NODE_1}):"
+    echo "Check DRBD status on ${NODE_0} (repeat with ${NODE_1}):"
     echo "  oc debug -q node/${NODE_0} -- chroot /host podman run --rm --privileged \\"
     echo "    -v /dev:/dev -v ${DRBD_CONF_PATH}:${DRBD_CONF_PATH} -v ${DRBD_DIR_PATH}:${DRBD_DIR_PATH} \\"
     echo "    --hostname ${NODE_0} --net host ${DRBD_IMAGE} drbdadm -c ${DRBD_CONF_PATH} status ${DRBD_RESOURCE}"


### PR DESCRIPTION
## Summary
- **Depends on #1171 and the pre-upgrade PR** (merge in order; diff shrinks as earlier PRs land)
- Recreate KMM Module with versioned kmod tags; wait for and validate new kmods
- `drbdadm up` on upgrade (preserve metadata), recreate autostart DaemonSet
- Restore floating mon and refresh success ConfigMap
- Bump defaults to DRBD `v4.22.0` / `9.2.18`

## Test plan
- [ ] Rebase onto master after prior PRs merge
- [ ] Full install → upgrade: new kmods, DRBD up, mon restored
- [ ] Run `make gen-csv` and commit OLM ConfigMap separately if needed

Ref-https://redhat.atlassian.net/browse/RHSTOR-9003