### PR TITLE
DFBUGS-7128: [4.21] mon: Prevent mon drains more reliably when mons are down

### DIFF
--- a/pkg/operator/ceph/cluster/mon/drain.go
+++ b/pkg/operator/ceph/cluster/mon/drain.go
@@ -18,9 +18,11 @@ package mon
 
 import (
 	"github.com/pkg/errors"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/log"
 	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -31,23 +33,54 @@ const (
 	monPDBName = "rook-ceph-mon-pdb"
 )
 
-func (c *Cluster) reconcileMonPDB() error {
+func (c *Cluster) reconcileMonPDB() (*cephclient.MonStatusResponse, error) {
 	if !c.spec.DisruptionManagement.ManagePodBudgets {
 		// TODO: Delete mon PDB
-		return nil
+		return nil, nil
 	}
 
 	monCount := c.spec.Mon.Count
 	if monCount <= 2 {
 		log.NamespacedDebug(c.Namespace, logger, "managePodBudgets is set, but mon-count <= 2. Not creating a disruptionbudget for Mons")
-		return nil
+		return nil, nil
 	}
 
-	op, err := c.createOrUpdateMonPDB(c.getMaxUnavailableMonPodCount())
+	// get the status and check for quorum
+	quorumStatus, err := cephclient.GetMonQuorumStatus(c.context, c.ClusterInfo)
 	if err != nil {
-		return errors.Wrapf(err, "failed to reconcile mon pdb on op %q", op)
+		return nil, errors.Wrap(err, "failed to get mon quorum status")
 	}
-	return nil
+	log.NamespacedDebug(c.Namespace, logger, "Mon quorum status: %+v", quorumStatus)
+
+	downMonCount := len(quorumStatus.MonMap.Mons) - len(quorumStatus.Quorum)
+
+	// If any mons are currently down, reduce the number of mons that can be drained
+	// to prevent more drains until the mon quorum can sufficiently handle another
+	// mon going down. This may block drains temporarily for longer than strictly needed,
+	// but will also prevent race conditions that would allow quorum to be lost
+	// if another node is drained before a down mon is fully back in quorum.
+	// nolint:gosec // G115 - casting will not cause overflow
+	allowedDown := c.getMaxUnavailableMonPodCount() - int32(downMonCount)
+	if allowedDown < 0 {
+		allowedDown = 0
+	}
+
+	// only update the mon pdb if the maxunavailable changed
+	currentMaxUnavailable, err := c.getExistingMaxUnavailable()
+	if err != nil {
+		log.NamespacedWarning(c.Namespace, logger, "failed to get current mon pdb maxunavailable, proceeding with update. %v", err)
+	} else if currentMaxUnavailable == allowedDown {
+		log.NamespacedDebug(c.Namespace, logger, "mon pdb maxunavailable is already set to %d", allowedDown)
+		return &quorumStatus, nil
+	}
+
+	// update the mon pdb since the maxunavailable changed
+	log.NamespacedInfo(c.Namespace, logger, "setting mon pdb maxUnavailable=%d (%d mons down)", allowedDown, downMonCount)
+	op, err := c.createOrUpdateMonPDB(allowedDown)
+	if err != nil {
+		return &quorumStatus, errors.Wrapf(err, "failed to reconcile mon pdb on op %q", op)
+	}
+	return &quorumStatus, nil
 }
 
 func (c *Cluster) createOrUpdateMonPDB(maxUnavailable int32) (controllerutil.OperationResult, error) {
@@ -72,31 +105,19 @@ func (c *Cluster) createOrUpdateMonPDB(maxUnavailable int32) (controllerutil.Ope
 	return controllerutil.CreateOrUpdate(c.ClusterInfo.Context, c.context.Client, pdb, mutateFunc)
 }
 
-// blockMonDrain makes MaxUnavailable in mon PDB to 0 to block any voluntary mon drains
-func (c *Cluster) blockMonDrain(request types.NamespacedName) error {
-	if !c.spec.DisruptionManagement.ManagePodBudgets {
-		return nil
-	}
-	log.NamespacedInfo(c.Namespace, logger, "prevent voluntary mon drain while failing over")
-	// change MaxUnavailable mon PDB to 0
-	_, err := c.createOrUpdateMonPDB(0)
+func (c *Cluster) getExistingMaxUnavailable() (int32, error) {
+	pdbRequest := types.NamespacedName{Name: monPDBName, Namespace: c.Namespace}
+	existingPDB := &policyv1.PodDisruptionBudget{}
+	err := c.context.Client.Get(c.ClusterInfo.Context, pdbRequest, existingPDB)
 	if err != nil {
-		return errors.Wrapf(err, "failed to update MaxUnavailable for mon PDB %q", request.Name)
+		if apierrors.IsNotFound(err) {
+			log.NamespacedDebug(c.Namespace, logger, "mon pdb %q not found", monPDBName)
+			return -1, nil
+		}
+		return 0, errors.Wrapf(err, "failed to get mon pdb %q", existingPDB.Name)
 	}
-	return nil
-}
-
-// allowMonDrain updates the MaxUnavailable in mon PDB to 1 to allow voluntary mon drains
-func (c *Cluster) allowMonDrain(request types.NamespacedName) error {
-	if !c.spec.DisruptionManagement.ManagePodBudgets {
-		return nil
-	}
-	log.NamespacedInfo(c.Namespace, logger, "allow voluntary mon drain after failover")
-	_, err := c.createOrUpdateMonPDB(c.getMaxUnavailableMonPodCount())
-	if err != nil {
-		return errors.Wrapf(err, "failed to update MaxUnavailable for mon PDB %q", request.Name)
-	}
-	return nil
+	log.NamespacedDebug(c.Namespace, logger, "existing mon pdb maxUnavailable=%d", existingPDB.Spec.MaxUnavailable.IntVal)
+	return existingPDB.Spec.MaxUnavailable.IntVal, nil
 }
 
 func (c *Cluster) getMaxUnavailableMonPodCount() int32 {

--- a/pkg/operator/ceph/cluster/mon/drain_test.go
+++ b/pkg/operator/ceph/cluster/mon/drain_test.go
@@ -18,15 +18,22 @@ package mon
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	"github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	policyv1 "k8s.io/api/policy/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -36,7 +43,23 @@ const (
 	mockNamespace = "test-ns"
 )
 
-func createFakeCluster(t *testing.T, cephClusterObj *cephv1.CephCluster, k8sVersion string) *Cluster {
+// createMonQuorumResponse creates a mock quorum status response with specified mons and quorum
+func createMonQuorumResponse(monNames []string, quorumRanks []int) string {
+	resp := cephclient.MonStatusResponse{Quorum: quorumRanks}
+	resp.MonMap.Mons = []cephclient.MonMapEntry{}
+	for i, name := range monNames {
+		resp.MonMap.Mons = append(resp.MonMap.Mons, cephclient.MonMapEntry{
+			Name:    name,
+			Rank:    i,
+			Address: fmt.Sprintf("1.2.3.%d", i+1),
+		})
+	}
+	serialized, _ := json.Marshal(resp)
+	return string(serialized)
+}
+
+// createFakeClusterWithExecutor creates a fake cluster with optional executor for mocking ceph commands
+func createFakeClusterWithExecutor(t *testing.T, cephClusterObj *cephv1.CephCluster, k8sVersion string, executor *exectest.MockExecutor) *Cluster {
 	ctx := context.TODO()
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	scheme := scheme.Scheme
@@ -45,7 +68,15 @@ func createFakeCluster(t *testing.T, cephClusterObj *cephv1.CephCluster, k8sVers
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects().Build()
 	clientset := test.New(t, 3)
-	c := New(ctx, &clusterd.Context{Client: cl, Clientset: clientset}, mockNamespace, cephClusterObj.Spec, ownerInfo)
+
+	clusterdContext := &clusterd.Context{
+		Client:    cl,
+		Clientset: clientset,
+		Executor:  executor,
+	}
+
+	c := New(ctx, clusterdContext, mockNamespace, cephClusterObj.Spec, ownerInfo)
+	c.ClusterInfo = clienttest.CreateTestClusterInfo(int(cephClusterObj.Spec.Mon.Count))
 	test.SetFakeKubernetesVersion(clientset, k8sVersion)
 	return c
 }
@@ -54,24 +85,67 @@ func TestReconcileMonPDB(t *testing.T) {
 	testCases := []struct {
 		name                   string
 		cephCluster            *cephv1.CephCluster
+		quorumResponse         string
 		expectedMaxUnAvailable int32
+		shouldCreatePDB        bool
 		errorExpected          bool
 	}{
 		{
-			name: "0 mons",
+			name: "managePodBudgets disabled",
 			cephCluster: &cephv1.CephCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: mockNamespace},
 				Spec: cephv1.ClusterSpec{
+					Mon: cephv1.MonSpec{
+						Count: 3,
+					},
+					DisruptionManagement: cephv1.DisruptionManagementSpec{
+						ManagePodBudgets: false,
+					},
+				},
+			},
+			quorumResponse:         clienttest.MonInQuorumResponse(),
+			expectedMaxUnAvailable: 0,
+			shouldCreatePDB:        false,
+			errorExpected:          false,
+		},
+		{
+			name: "mon count is 1",
+			cephCluster: &cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: mockNamespace},
+				Spec: cephv1.ClusterSpec{
+					Mon: cephv1.MonSpec{
+						Count: 1,
+					},
 					DisruptionManagement: cephv1.DisruptionManagementSpec{
 						ManagePodBudgets: true,
 					},
 				},
 			},
+			quorumResponse:         createMonQuorumResponse([]string{"a"}, []int{0}),
 			expectedMaxUnAvailable: 0,
-			errorExpected:          true,
+			shouldCreatePDB:        false,
+			errorExpected:          false,
 		},
 		{
-			name: "3 mons",
+			name: "mon count is 2",
+			cephCluster: &cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: mockNamespace},
+				Spec: cephv1.ClusterSpec{
+					Mon: cephv1.MonSpec{
+						Count: 2,
+					},
+					DisruptionManagement: cephv1.DisruptionManagementSpec{
+						ManagePodBudgets: true,
+					},
+				},
+			},
+			quorumResponse:         createMonQuorumResponse([]string{"a", "b"}, []int{0, 1}),
+			expectedMaxUnAvailable: 0,
+			shouldCreatePDB:        false,
+			errorExpected:          false,
+		},
+		{
+			name: "3 mons - all in quorum",
 			cephCluster: &cephv1.CephCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: mockNamespace},
 				Spec: cephv1.ClusterSpec{
@@ -83,11 +157,31 @@ func TestReconcileMonPDB(t *testing.T) {
 					},
 				},
 			},
+			quorumResponse:         createMonQuorumResponse([]string{"a", "b", "c"}, []int{0, 1, 2}),
 			expectedMaxUnAvailable: 1,
+			shouldCreatePDB:        true,
 			errorExpected:          false,
 		},
 		{
-			name: "5 mons",
+			name: "3 mons - 1 mon down",
+			cephCluster: &cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: mockNamespace},
+				Spec: cephv1.ClusterSpec{
+					Mon: cephv1.MonSpec{
+						Count: 3,
+					},
+					DisruptionManagement: cephv1.DisruptionManagementSpec{
+						ManagePodBudgets: true,
+					},
+				},
+			},
+			quorumResponse:         createMonQuorumResponse([]string{"a", "b", "c"}, []int{0, 1}),
+			expectedMaxUnAvailable: 0, // maxUnavailable=1, downMonCount=1, allowedDown=1-1=0
+			shouldCreatePDB:        true,
+			errorExpected:          false,
+		},
+		{
+			name: "5 mons - all in quorum",
 			cephCluster: &cephv1.CephCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: mockNamespace},
 				Spec: cephv1.ClusterSpec{
@@ -99,71 +193,152 @@ func TestReconcileMonPDB(t *testing.T) {
 					},
 				},
 			},
+			quorumResponse:         createMonQuorumResponse([]string{"a", "b", "c", "d", "e"}, []int{0, 1, 2, 3, 4}),
 			expectedMaxUnAvailable: 2,
+			shouldCreatePDB:        true,
+			errorExpected:          false,
+		},
+		{
+			name: "5 mons - 1 mon down",
+			cephCluster: &cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: mockNamespace},
+				Spec: cephv1.ClusterSpec{
+					Mon: cephv1.MonSpec{
+						Count: 5,
+					},
+					DisruptionManagement: cephv1.DisruptionManagementSpec{
+						ManagePodBudgets: true,
+					},
+				},
+			},
+			quorumResponse:         createMonQuorumResponse([]string{"a", "b", "c", "d", "e"}, []int{0, 1, 2, 3}),
+			expectedMaxUnAvailable: 1, // maxUnavailable=2, downMonCount=1, allowedDown=2-1=1
+			shouldCreatePDB:        true,
+			errorExpected:          false,
+		},
+		{
+			name: "5 mons - 2 mons down",
+			cephCluster: &cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: mockNamespace},
+				Spec: cephv1.ClusterSpec{
+					Mon: cephv1.MonSpec{
+						Count: 5,
+					},
+					DisruptionManagement: cephv1.DisruptionManagementSpec{
+						ManagePodBudgets: true,
+					},
+				},
+			},
+			quorumResponse:         createMonQuorumResponse([]string{"a", "b", "c", "d", "e"}, []int{0, 1, 2}),
+			expectedMaxUnAvailable: 0, // maxUnavailable=2, downMonCount=2, allowedDown=2-2=0
+			shouldCreatePDB:        true,
+			errorExpected:          false,
+		},
+		{
+			name: "5 mons - 3 mons down (edge case)",
+			cephCluster: &cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "rook", Namespace: mockNamespace},
+				Spec: cephv1.ClusterSpec{
+					Mon: cephv1.MonSpec{
+						Count: 5,
+					},
+					DisruptionManagement: cephv1.DisruptionManagementSpec{
+						ManagePodBudgets: true,
+					},
+				},
+			},
+			quorumResponse:         createMonQuorumResponse([]string{"a", "b", "c", "d", "e"}, []int{0, 1}),
+			expectedMaxUnAvailable: 0, // maxUnavailable=2, downMonCount=3, allowedDown=2-3=-1, clamped to 0
+			shouldCreatePDB:        true,
 			errorExpected:          false,
 		},
 	}
 
 	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &exectest.MockExecutor{
+				MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+					if strings.Contains(command, "quorum_status") || (len(args) > 0 && args[0] == "quorum_status") {
+						return tc.quorumResponse, nil
+					}
+					return "", nil
+				},
+			}
 
-		// check for PDBV1 version
-		c := createFakeCluster(t, tc.cephCluster, "v1.21.0")
-		err := c.reconcileMonPDB()
-		assert.NoError(t, err)
-		existingPDBV1 := &policyv1.PodDisruptionBudget{}
-		err = c.context.Client.Get(context.TODO(), types.NamespacedName{Name: monPDBName, Namespace: mockNamespace}, existingPDBV1)
-		if tc.errorExpected {
-			assert.Error(t, err)
-			continue
-		}
-		assert.NoError(t, err)
-		// nolint:gosec // G115 no overflow expected in the test
-		assert.Equalf(t, tc.expectedMaxUnAvailable, int32(existingPDBV1.Spec.MaxUnavailable.IntValue()), "[%s]: incorrect minAvailable count in pdb", tc.name)
+			c := createFakeClusterWithExecutor(t, tc.cephCluster, "v1.21.0", executor)
+			quorumStatus, err := c.reconcileMonPDB()
+			if tc.errorExpected {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
 
-		// reconcile mon PDB again to test update
-		err = c.reconcileMonPDB()
-		assert.NoError(t, err)
+			existingPDB := &policyv1.PodDisruptionBudget{}
+			err = c.context.Client.Get(context.TODO(), types.NamespacedName{Name: monPDBName, Namespace: mockNamespace}, existingPDB)
+
+			if !tc.shouldCreatePDB {
+				assert.Nil(t, quorumStatus)
+				assert.True(t, kerrors.IsNotFound(err), "PDB should not exist for test case: %s", tc.name)
+				return
+			}
+			assert.NotNil(t, quorumStatus)
+
+			require.NoError(t, err, "Failed to get PDB for test case: %s", tc.name)
+			// nolint:gosec // G115 no overflow expected in the test
+			assert.Equalf(t, tc.expectedMaxUnAvailable, int32(existingPDB.Spec.MaxUnavailable.IntValue()),
+				"[%s]: incorrect maxUnavailable count in pdb", tc.name)
+
+			// reconcile mon PDB again to test update
+			quorumStatus, err = c.reconcileMonPDB()
+			assert.NoError(t, err)
+			assert.NotNil(t, quorumStatus)
+
+			err = c.context.Client.Delete(context.TODO(), existingPDB)
+			assert.NoError(t, err)
+		})
 	}
 }
 
-func TestAllowMonDrain(t *testing.T) {
-	fakeNamespaceName := types.NamespacedName{Namespace: mockNamespace, Name: monPDBName}
-	// check for PDBV1 version
-	c := createFakeCluster(t, &cephv1.CephCluster{
-		Spec: cephv1.ClusterSpec{
-			DisruptionManagement: cephv1.DisruptionManagementSpec{
-				ManagePodBudgets: true,
-			},
+func TestGetMaxUnavailableMonPodCount(t *testing.T) {
+	testCases := []struct {
+		name        string
+		monCount    int
+		expectedMax int32
+	}{
+		{
+			name:        "1 mon",
+			monCount:    1,
+			expectedMax: 1,
 		},
-	}, "v1.21.0")
-	t.Run("allow mon drain for K8s version v1.21.0", func(t *testing.T) {
-		// change MaxUnavailable mon PDB to 1
-		err := c.allowMonDrain(fakeNamespaceName)
-		assert.NoError(t, err)
-		existingPDBV1 := &policyv1.PodDisruptionBudget{}
-		err = c.context.Client.Get(context.TODO(), fakeNamespaceName, existingPDBV1)
-		assert.NoError(t, err)
-		assert.Equal(t, 1, int(existingPDBV1.Spec.MaxUnavailable.IntValue()))
-	})
-}
+		{
+			name:        "3 mons",
+			monCount:    3,
+			expectedMax: 1,
+		},
+		{
+			name:        "5 mons",
+			monCount:    5,
+			expectedMax: 2,
+		},
+		{
+			name:        "7 mons",
+			monCount:    7,
+			expectedMax: 2,
+		},
+	}
 
-func TestBlockMonDrain(t *testing.T) {
-	fakeNamespaceName := types.NamespacedName{Namespace: mockNamespace, Name: monPDBName}
-	// check for PDBV1 version
-	c := createFakeCluster(t, &cephv1.CephCluster{
-		Spec: cephv1.ClusterSpec{
-			DisruptionManagement: cephv1.DisruptionManagementSpec{
-				ManagePodBudgets: true,
-			},
-		},
-	}, "v1.21.0")
-	t.Run("block mon drain for K8s version v1.21.0", func(t *testing.T) {
-		// change MaxUnavailable mon PDB to 0
-		err := c.blockMonDrain(fakeNamespaceName)
-		assert.NoError(t, err)
-		existingPDBV1 := &policyv1.PodDisruptionBudget{}
-		err = c.context.Client.Get(context.TODO(), fakeNamespaceName, existingPDBV1)
-		assert.NoError(t, err)
-		assert.Equal(t, 0, int(existingPDBV1.Spec.MaxUnavailable.IntValue()))
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Cluster{
+				spec: cephv1.ClusterSpec{
+					Mon: cephv1.MonSpec{
+						Count: tc.monCount,
+					},
+				},
+				Namespace: mockNamespace,
+			}
+			actual := c.getMaxUnavailableMonPodCount()
+			assert.Equal(t, tc.expectedMax, actual, "getMaxUnavailableMonPodCount returned wrong value for %d mons", tc.monCount)
+		})
+	}
 }

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -34,7 +34,6 @@ import (
 	"github.com/rook/rook/pkg/util/log"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -199,13 +198,25 @@ func (c *Cluster) checkHealth(ctx context.Context) error {
 		return nil
 	}
 
-	// connect to the mons
-	// get the status and check for quorum
-	quorumStatus, err := cephclient.GetMonQuorumStatus(c.context, c.ClusterInfo)
+	// Update the mon PDBs in case any mons have joined or left the quorum.
+	// If any mons are out of quorum, this prevents more mons from being drained
+	// until we know the mon quorum is stable with full quorum.
+	qStatus, err := c.reconcileMonPDB()
 	if err != nil {
-		return errors.Wrap(err, "failed to get mon quorum status")
+		logger.Errorf("failed to update mon pdb. %v", err)
 	}
-	log.NamespacedDebug(c.Namespace, logger, "Mon quorum status: %+v", quorumStatus)
+
+	var quorumStatus cephclient.MonStatusResponse
+	if qStatus == nil {
+		// If the mon status was not queried by the pdb reconcile, query it here
+		quorumStatus, err = cephclient.GetMonQuorumStatus(c.context, c.ClusterInfo)
+		if err != nil {
+			return errors.Wrap(err, "failed to get mon quorum status")
+		}
+		log.NamespacedDebug(c.Namespace, logger, "Mon quorum status: %+v", quorumStatus)
+	} else {
+		quorumStatus = *qStatus
+	}
 
 	// handle external Mons
 	quorumStatus, err = c.reconcileExternalMons(ctx, quorumStatus)
@@ -652,19 +663,14 @@ func (c *Cluster) failMon(monCount, desiredMonCount int, name string) bool {
 		return true
 	}
 
-	// prevent any voluntary mon drain while failing over
-	if err := c.blockMonDrain(types.NamespacedName{Name: monPDBName, Namespace: c.Namespace}); err != nil {
-		log.NamespacedError(c.Namespace, logger, "failed to block mon drain. %v", err)
-	}
-
 	// bring up a new mon to replace the unhealthy mon
 	if err := c.failoverMon(name); err != nil {
 		log.NamespacedError(c.Namespace, logger, "failed to failover mon %q. %v", name, err)
 	}
 
-	// allow any voluntary mon drain after failover
-	if err := c.allowMonDrain(types.NamespacedName{Name: monPDBName, Namespace: c.Namespace}); err != nil {
-		log.NamespacedError(c.Namespace, logger, "failed to allow mon drain. %v", err)
+	// Reset the mon pdb since the quorum is likely healthy again after the failover.
+	if _, err := c.reconcileMonPDB(); err != nil {
+		logger.Errorf("failed to update mon pdb. %v", err)
 	}
 	return true
 }

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -321,7 +321,7 @@ func (c *Cluster) startMons(targetCount int) error {
 	log.NamespacedDebug(c.Namespace, logger, "mon endpoints used are: %s", flattenMonEndpoints(c.ClusterInfo.AllMonitors()))
 
 	// reconcile mon PDB
-	if err := c.reconcileMonPDB(); err != nil {
+	if _, err := c.reconcileMonPDB(); err != nil {
 		return errors.Wrap(err, "failed to reconcile mon PDB")
 	}
 


### PR DESCRIPTION
The mon PDB was previously only being adjusted during mon failover, where the maxunavailable was set to 0 before failover, then reset to 1 after failover. This allowed for a race condition where one mon had been drained and is not fully back in quorum before the next mon is allowed to drain. This is now prevented by disallowing drains until a mon is fully back in quorum. Anytime a mon falls out of quorum, the mon pdb will be adjusted to prevent further drains from causing a mon quorum outage.

Resolves: https://redhat.atlassian.net/browse/DFBUGS-7128

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
