### PR TITLE
DFBUGS-4518: [release-4.16] Bump go (stdlib: net/http) from 1.21 to 1.21.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rook/rook
 
-go 1.21
+go 1.21.9
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/rook/rook/pkg/apis
 
-go 1.21
+go 1.21.9
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1


### PR DESCRIPTION
### Changes
- **go (stdlib: net/http)**: `1.21` → `1.21.9` (in `go.mod`)
- **go (stdlib: net/http)**: `1.21` → `1.21.9` (in `pkg/apis/go.mod`)
