### PR TITLE
[release-4.22] Bump go (stdlib) from 1.25.0 to 1.25.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rook/rook
 
-go 1.25.0
+go 1.25.2
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/rook/rook/pkg/apis
 
-go 1.25.0
+go 1.25.2
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.25.0` → `1.25.2` (in `go.mod`)
- **go (stdlib)**: `1.25.0` → `1.25.2` (in `pkg/apis/go.mod`)
