### PR TITLE
DFBUGS-7980: core: reduce the floating mon reschdule time

### DIFF
--- a/pkg/operator/ceph/cluster/mon/template/floating-mon-drbd-deployment.yaml
+++ b/pkg/operator/ceph/cluster/mon/template/floating-mon-drbd-deployment.yaml
@@ -65,7 +65,11 @@ spec:
         - effect: NoExecute
           key: node.kubernetes.io/not-ready
           operator: Exists
-          tolerationSeconds: 120
+          tolerationSeconds: 5
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 5
       {{ if .PRIORITY_CLASS_NAME }}
       priorityClassName: {{ .PRIORITY_CLASS_NAME }}
       {{ end }}


### PR DESCRIPTION
currently k8s add the default eviction time as 300 sec setting it to 5 sec for the quick re-schedule


(cherry picked from commit 9e0b6e5bbe9b9813f075fa919641648358ee97e4)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
