### PR TITLE
DFBUGS-7723: [release-4.21] Bump go (stdlib) from 1.24.10 to 1.24.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rook/rook
 
-go 1.24.10
+go 1.24.12
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/rook/rook/pkg/apis
 
-go 1.24.10
+go 1.24.12
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.10` → `1.24.12` (in `go.mod`)
- **go (stdlib)**: `1.24.10` → `1.24.12` (in `pkg/apis/go.mod`)
